### PR TITLE
setup: discount npx's own PATH entry when choosing the invocation

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -10,11 +10,23 @@ const here = path.dirname(fileURLToPath(import.meta.url));
  * Teach agents the command that will actually work here. A global install or
  * `npm link` puts `human-review` on PATH; otherwise fall back to npx, which only
  * resolves once the package is published.
+ *
+ * The probe has to discount its own npx run. `npx -y human-review setup --global`
+ * puts this package on PATH for the duration of that one command, out of npm's
+ * `_npx` cache, so a naive `which` succeeds and setup writes a bare
+ * `human-review` into SKILL.md. That binary is gone the moment npx exits, and
+ * every later agent invocation dies with "command not found".
  */
 export function invocation() {
   const probe = process.platform === "win32" ? "where" : "which";
   const found = spawnSync(probe, ["human-review"], { encoding: "utf8" });
-  return found.status === 0 && found.stdout.trim() ? "human-review" : "npx -y human-review";
+  const resolved = found.status === 0 ? found.stdout.trim().split(/\r?\n/)[0].trim() : "";
+  return resolved && !isNpxCachePath(resolved) ? "human-review" : "npx -y human-review";
+}
+
+/** True for a binary npm placed in its transient `_npx` cache for one command. */
+export function isNpxCachePath(binPath) {
+  return binPath.split(/[\\/]/).includes("_npx");
 }
 
 /**

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { installSkills } from "../src/setup.js";
+import { installSkills, isNpxCachePath } from "../src/setup.js";
 
 test("global setup installs the skill for Claude Code, Codex, and shared agents", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-setup-"));
@@ -22,4 +22,26 @@ test("global setup installs the skill for Claude Code, Codex, and shared agents"
   } finally {
     fs.rmSync(home, { recursive: true, force: true });
   }
+});
+
+test("a binary from npm's _npx cache does not count as installed on PATH", () => {
+  // `npx -y human-review setup --global` resolves `which human-review` to the
+  // transient cache copy, which disappears when npx exits. Writing a bare
+  // `human-review` into SKILL.md on the strength of that leaves every later
+  // agent run failing with "command not found".
+  assert.equal(
+    isNpxCachePath("/Users/x/.npm/_npx/f043fcd613c7efad/node_modules/.bin/human-review"),
+    true,
+  );
+  assert.equal(
+    isNpxCachePath("C:\\Users\\x\\AppData\\Local\\npm-cache\\_npx\\a1b2\\human-review.cmd"),
+    true,
+  );
+
+  // A real global install or `npm link` must still win.
+  assert.equal(isNpxCachePath("/opt/homebrew/bin/human-review"), false);
+  assert.equal(isNpxCachePath("/usr/local/bin/human-review"), false);
+
+  // `_npx` only counts as a path segment, never as a substring of one.
+  assert.equal(isNpxCachePath("/Users/x/my_npx_tools/bin/human-review"), false);
 });


### PR DESCRIPTION
> **Correction, after this was merged.** Two claims below are wrong and the fix
> is narrower than it should be. Details and a patch are in #7.
> Leaving the original text intact so the record of what was merged is accurate.

---

`npx -y human-review setup --global` writes a SKILL.md that tells agents to run a bare `human-review`. On a machine without a global install that command does not exist, so every later invocation fails with "command not found".

`invocation()` probes `which human-review` to decide which form to write. The probe runs inside the npx call that is doing the setup, and npx has put the package on PATH for the duration of that one command:

```
$ which human-review
/Users/me/.npm/_npx/f043fcd613c7efad/node_modules/.bin/human-review
```

That path is gone the moment npx exits, so the probe reports an install that was never there.

This change ignores a resolution living inside npm's `_npx` cache and falls back to `npx -y human-review`. A real global install or `npm link` still wins.

Checked all three cases against `invocation()` on macOS, node 25.9.0:

| PATH holds | resolves to | invocation() |
| --- | --- | --- |
| the npx cache copy | `~/.npm/_npx/<hash>/node_modules/.bin/human-review` | `npx -y human-review` |
| a real bin dir | `/tmp/.../bin/human-review` | `human-review` |
| nothing | | `npx -y human-review` |

One test added, covering the cache path on both platforms, a real global install, and a directory that merely contains the characters `_npx`. 68 pass.

Found this installing the skill today, so the SKILL.md on my machine needed the `npx -y` prefix put back by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
