### PR TITLE
Fix terminal flashes during inline editing on Windows

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -96,6 +96,7 @@ async function fetchLocalPage(target, redirects = 0) {
 
 export function createServer() {
   const store = new Store();
+  const cliInvocation = invocation();
 
   /**
    * Random per-run secret. Every /api route requires it, so a malicious web
@@ -412,7 +413,7 @@ export function createServer() {
       comments: page.comments,
       edits: page.edits,
       canRevert: page.kind !== "url" && typeof page.pristine === "string" && page.pristine.length > 0,
-      pollCommand: `${invocation()} poll ${shellQuote(pollTarget)}`,
+      pollCommand: `${cliInvocation} poll ${shellQuote(pollTarget)}`,
     };
   }
 

--- a/src/setup.js
+++ b/src/setup.js
@@ -17,9 +17,9 @@ const here = path.dirname(fileURLToPath(import.meta.url));
  * `human-review` into SKILL.md. That binary is gone the moment npx exits, and
  * every later agent invocation dies with "command not found".
  */
-export function invocation() {
+export function invocation(run = spawnSync) {
   const probe = process.platform === "win32" ? "where" : "which";
-  const found = spawnSync(probe, ["human-review"], { encoding: "utf8" });
+  const found = run(probe, ["human-review"], { encoding: "utf8", windowsHide: true });
   const resolved = found.status === 0 ? found.stdout.trim().split(/\r?\n/)[0].trim() : "";
   return resolved && !isNpxCachePath(resolved) ? "human-review" : "npx -y human-review";
 }

--- a/test/command-cache.test.js
+++ b/test/command-cache.test.js
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { once } from "node:events";
+
+import { createServer } from "../src/server.js";
+
+test("a review keeps the CLI invocation resolved when its server starts", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-command-"));
+  const originalPath = process.env.PATH;
+  const originalStateDir = process.env.HUMAN_REVIEW_STATE_DIR;
+  const bin = path.join(tmp, "bin");
+  const state = path.join(tmp, "state");
+  const file = path.join(tmp, "review.html");
+  const locatorPath = process.platform === "win32" ? path.join(process.env.SystemRoot, "System32") : "/usr/bin:/bin";
+
+  fs.mkdirSync(bin);
+  fs.writeFileSync(file, "<p>Review me</p>");
+  if (process.platform === "win32") {
+    fs.writeFileSync(path.join(bin, "human-review.cmd"), "@exit /b 0\r\n");
+  } else {
+    const command = path.join(bin, "human-review");
+    fs.writeFileSync(command, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(command, 0o755);
+  }
+
+  process.env.HUMAN_REVIEW_STATE_DIR = state;
+  process.env.PATH = `${bin}${path.delimiter}${locatorPath}`;
+  const review = createServer();
+  review.server.listen(0, "127.0.0.1");
+  await once(review.server, "listening");
+
+  try {
+    process.env.PATH = locatorPath;
+    const port = review.server.address().port;
+    const headers = { "x-human-review-token": review.token, "content-type": "application/json" };
+    const opened = await fetch(`http://127.0.0.1:${port}/api/session`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ file }),
+    }).then((response) => response.json());
+    const stateResponse = await fetch(`http://127.0.0.1:${port}/api/session/${opened.sessionId}/page`, { headers }).then((response) =>
+      response.json(),
+    );
+
+    assert.match(stateResponse.page.pollCommand, /^human-review poll /);
+  } finally {
+    const closed = once(review.server, "close");
+    review.dispose();
+    await closed;
+    process.env.PATH = originalPath;
+    if (originalStateDir === undefined) delete process.env.HUMAN_REVIEW_STATE_DIR;
+    else process.env.HUMAN_REVIEW_STATE_DIR = originalStateDir;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { installSkills, isNpxCachePath } from "../src/setup.js";
+import { installSkills, invocation, isNpxCachePath } from "../src/setup.js";
 
 test("global setup installs the skill for Claude Code, Codex, and shared agents", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-setup-"));
@@ -44,4 +44,14 @@ test("a binary from npm's _npx cache does not count as installed on PATH", () =>
 
   // `_npx` only counts as a path segment, never as a substring of one.
   assert.equal(isNpxCachePath("/Users/x/my_npx_tools/bin/human-review"), false);
+});
+
+test("the CLI lookup hides its child process window", () => {
+  let options;
+  invocation((_probe, _args, receivedOptions) => {
+    options = receivedOptions;
+    return { status: 1, stdout: "" };
+  });
+
+  assert.equal(options?.windowsHide, true);
 });


### PR DESCRIPTION
On Windows, each inline edit response rebuilt page state and called invocation(). That ran where human-review in a visible child console, which could flash and steal keyboard focus.\n\nThis change resolves the CLI invocation once when the server starts and passes windowsHide: true to the PATH probe.\n\nFocused tests cover both the cached invocation and the hidden child process.\n\nTest command: node --test test/command-cache.test.js test/setup.test.js\nResult: 4 passed, 0 failed.