### PR TITLE
Fix #hash-link navigation in single-file prototypes, and note-only sends

### DIFF
--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -288,11 +288,14 @@ function render() {
   // --- send
   const otherTotal = others.reduce((sum, o) => sum + o.count, 0);
   const total = comments.length + edits.length + otherTotal;
+  // An overall note is sendable on its own — the server already accepts
+  // note-only batches; the button must not stay dead while one is typed.
+  const hasNote = $("note").value.trim().length > 0;
   const send = $("send");
   const delivered = state.agent === "working";
   const stranded = state.agent === "stranded";
   const busy = delivered || stranded || state.sent;
-  send.disabled = total === 0 || busy;
+  send.disabled = (total === 0 && !hasNote) || busy;
   send.textContent = delivered
     ? "Feedback delivered"
     : stranded
@@ -301,7 +304,9 @@ function render() {
         ? "Sent — waiting for agent"
         : total
           ? `Send ${total} to agent`
-          : "Nothing to send yet";
+          : hasNote
+            ? "Send note to agent"
+            : "Nothing to send yet";
   if (!send.disabled) {
     const key = document.createElement("span");
     key.className = "key";
@@ -698,6 +703,7 @@ $("note").addEventListener("input", (event) => {
   const el = event.target;
   el.style.height = "auto";
   el.style.height = `${Math.min(el.scrollHeight + 2, window.innerHeight * 0.4)}px`;
+  render(); // keep the send button in step with note-only feedback
 });
 
 $("handle").addEventListener("click", () => {

--- a/src/click-target.js
+++ b/src/click-target.js
@@ -4,3 +4,23 @@ export function navigationHref(target) {
   const control = target?.closest?.("[data-href]");
   return control ? control.getAttribute("data-href") || "" : "";
 }
+
+/**
+ * Decide what a modified click on a "#…" link should do. Setting the real
+ * hash is what makes CSS :target routing (single-file "pages") show the
+ * section — a bare scrollIntoView can't reach a display:none target and
+ * never fires :target. Only when the hash is already current does scrolling
+ * become the right move, since re-setting an identical hash is a no-op.
+ */
+export function hashClickAction(href, currentHash) {
+  const decode = (value) => {
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  };
+  const id = decode(href.slice(1));
+  if (decode((currentHash || "").slice(1)) === id) return { kind: "scroll", id };
+  return { kind: "navigate", hash: href };
+}

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -6,7 +6,7 @@
  * talks to the server — everything crosses to the chrome page by postMessage.
  */
 import { buildContext, findQuote } from "./anchor-text.js";
-import { navigationHref } from "./click-target.js";
+import { hashClickAction, navigationHref } from "./click-target.js";
 import { keepBodyEditable, serializeDocument, UI_ATTR, MARK_ATTR } from "./serialize.js";
 
 const SAVE_DEBOUNCE_MS = 700;
@@ -620,7 +620,15 @@ function boot() {
           event.preventDefault();
           event.stopPropagation();
           if (/^(https?:)?\/\//i.test(href) || /^mailto:/i.test(href)) post("eh:external", { href: new URL(href, document.baseURI).href });
-          else if (href.startsWith("#")) document.querySelector(href)?.scrollIntoView({ behavior: "smooth" });
+          else if (href.startsWith("#")) {
+            const action = hashClickAction(href, location.hash);
+            if (action.kind === "scroll") {
+              const el = document.getElementById(action.id) || document.getElementsByName(action.id)[0] || document.body;
+              el.scrollIntoView({ behavior: "smooth" });
+            } else {
+              location.hash = action.hash;
+            }
+          }
           else {
             // This document is about to be torn down: anything still sitting in
             // the debounce windows must ship first or it is lost. Message order

--- a/test/click-target.test.js
+++ b/test/click-target.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { navigationHref } from "../src/click-target.js";
+import { hashClickAction, navigationHref } from "../src/click-target.js";
 
 function target({ link = null, control = null } = {}) {
   return {
@@ -22,4 +22,22 @@ test("navigationHref supports framework buttons with data-href", () => {
 
 test("navigationHref ignores ordinary controls", () => {
   assert.equal(navigationHref(target()), "");
+});
+
+test("hashClickAction sets the hash when it differs, so :target routing fires", () => {
+  assert.deepEqual(hashClickAction("#interview", ""), { kind: "navigate", hash: "#interview" });
+  assert.deepEqual(hashClickAction("#interview", "#overview"), { kind: "navigate", hash: "#interview" });
+});
+
+test("hashClickAction scrolls instead when the hash is already current", () => {
+  assert.deepEqual(hashClickAction("#interview", "#interview"), { kind: "scroll", id: "interview" });
+});
+
+test("hashClickAction matches encoded and decoded forms of the same hash", () => {
+  assert.deepEqual(hashClickAction("#caf%C3%A9", "#café"), { kind: "scroll", id: "café" });
+});
+
+test("hashClickAction survives malformed percent escapes", () => {
+  assert.deepEqual(hashClickAction("#%", ""), { kind: "navigate", hash: "#%" });
+  assert.deepEqual(hashClickAction("#%", "#%"), { kind: "scroll", id: "%" });
 });


### PR DESCRIPTION
Fixes #9 and fixes #10.

**1. Cmd+click on `#hash` links now works (#9)**

Single-file prototypes that fake multiple pages with CSS `:target` routing couldn't be navigated at all in review mode: the modified-click handler called `querySelector(href)?.scrollIntoView(...)` after `preventDefault()`, which never changes the URL hash (so `:target` never fires) and can't scroll to a `display:none` section. It also threw on hashes that aren't valid selectors (`#1st-section`).

Now a modified click on a `#hash` link sets `location.hash` — same-document navigation is permitted inside the sandboxed frame, so this is safe under `allow-scripts` without `allow-same-origin` — and falls back to a smooth scroll only when that hash is already current. The decision is a pure function, `hashClickAction` in `click-target.js`, with unit tests covering encoded-vs-decoded hash matching and malformed percent escapes; the scroll fallback also finds legacy `<a name>` anchors.

**2. Note-only feedback can now be sent (#10)**

The server already accepts note-only batches, but the send button only counted comments and edits, so an overall note with no other feedback could never be sent. A non-empty note now counts toward enablement (labelled "Send note to agent"), and the rail re-renders on note input so the button wakes up while typing.

**Testing**

- `npm test`: 72/72 pass (4 new tests for `hashClickAction`).
- Verified end-to-end in Chrome against a real single-file `:target`-routed prototype: before, Cmd+click did nothing; after, Cmd+click switches pages, same-hash clicks scroll, external links still open in a new tab, and a note-only send enables and delivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)