### PR TITLE
Editor: lists anywhere, ⌘K links, drag-to-move images, agent-chat handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ Note: For HTML files, direct edits and resizes save automatically. For Markdown 
 ## What this skill lets you do
 
 - **Edit text directly and tweak basic formatting** (e.g., bold, italic).
-- **Make bulleted and numbered lists** — type `- ` or `1. ` on an empty line, or press ⌘⇧8 / ⌘⇧7. Tab and Shift+Tab indent and outdent.
-- **Resize images** by dragging their corner.
+- **Make bulleted and numbered lists** — type `- ` or `1. ` at the start of a line, or press ⌘⇧8 / ⌘⇧7. Tab and Shift+Tab indent and outdent.
+- **Add links** — select text and press ⌘K. ⌘K inside an existing link edits or removes it.
+- **Resize images** by dragging their corner, and **move images** by dragging them to a new spot.
 - **Select a phrase and leave a comment** anchored to the exact text.
 - **Comment on an image, chart, or section** by clicking the element.
 - **Remove elements** without explaining the deletion in chat.

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -5,6 +5,7 @@
  * hostname: a separate origin that can never reach this page or its token.
  */
 import { tidy } from "./anchor-text.js";
+import { pageUrl, replacePage } from "./chrome-session.js";
 import { framePolicy } from "./frame-policy.js";
 
 const $ = (id) => document.getElementById(id);
@@ -30,6 +31,17 @@ const state = {
   dynamic: false,
   framePolicy: null,
 };
+
+/**
+ * Most reviewers drive an agent from a chat (Claude Code, Codex, Cursor), not
+ * a bare terminal — so the handoff is a prompt the agent can act on, with the
+ * poll command embedded for anyone who does live in a shell.
+ */
+function handoffPrompt(pollCommand) {
+  const cmd = String(pollCommand || "").trim();
+  if (!cmd) return "";
+  return `Run \`${cmd} --timeout 600\`, apply the feedback it returns, then keep polling with --ack until I end the review.`;
+}
 
 // ------------------------------------------------------------------- server
 
@@ -84,10 +96,9 @@ function flushFrame() {
 async function loadPage(key, { reload = true } = {}) {
   const returning = state.page;
   state.key = key;
-  state.page = await api(`/api/page/${key}?session=${state.sessionId}`);
+  replacePage(state, await api(pageUrl(key, state.sessionId)));
   state.framePolicy = framePolicy(state.page, ARTIFACT_ORIGIN);
   frame.setAttribute("sandbox", state.framePolicy.sandbox);
-  state.others = state.page.others || [];
   state.orphans = new Set();
   state.compose = null;
   state.active = null;
@@ -316,7 +327,7 @@ function render() {
 
   // Server-authoritative, so it survives a browser refresh.
   $("handoff").hidden = !stranded;
-  if (stranded) $("handoffCmd").textContent = state.pollCommand || page.pollCommand || "";
+  if (stranded) $("handoffCmd").textContent = handoffPrompt(state.pollCommand || page.pollCommand);
 }
 
 function renderSave() {
@@ -687,10 +698,10 @@ $("handoffCopy").addEventListener("click", async (event) => {
     await navigator.clipboard.writeText($("handoffCmd").textContent);
     button.textContent = "Copied";
     setTimeout(() => {
-      button.textContent = "Copy command";
+      button.textContent = "Copy prompt";
     }, 1600);
   } catch {
-    toast("Couldn't copy — select the command and copy it manually");
+    toast("Couldn't copy — select the prompt and copy it manually");
   }
 });
 
@@ -761,8 +772,8 @@ function connect() {
     state.baseHash = null;
     clearTimeout(retryTimer);
     frame.src = artifactUrl(state.key, true);
-    api(`/api/page/${state.key}`).then((page) => {
-      state.page = page;
+    api(pageUrl(state.key, state.sessionId)).then((page) => {
+      replacePage(state, page);
       state.save = "idle";
       state.savedAt = "";
       render();
@@ -777,7 +788,7 @@ function connect() {
     render();
   });
   source.addEventListener("refresh", async () => {
-    state.page = await api(`/api/page/${state.key}`);
+    replacePage(state, await api(pageUrl(state.key, state.sessionId)));
     state.sent = false;
     render();
   });

--- a/src/chrome-session.js
+++ b/src/chrome-session.js
@@ -1,0 +1,8 @@
+export function pageUrl(key, sessionId) {
+  return `/api/page/${key}?session=${encodeURIComponent(sessionId)}`;
+}
+
+export function replacePage(state, page) {
+  state.page = page;
+  state.others = page.others || [];
+}

--- a/src/chrome.css
+++ b/src/chrome.css
@@ -426,7 +426,8 @@ body.collapsed .handle { right: 0; }
 }
 .handoff-cmd code {
   font: 11.5px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 .handoff .btn-ghost { padding: 5px 9px; font-size: 11.5px; }
 

--- a/src/chrome.html
+++ b/src/chrome.html
@@ -69,9 +69,9 @@
         <div class="agent-line" id="agentLine" hidden><span class="dot amber"></span><span id="agentText"></span></div>
         <div class="handoff" id="handoff" hidden>
           <p class="handoff-title">Sent — but no agent is listening yet.</p>
-          <p class="handoff-body">Run this in the terminal where your agent is working:</p>
+          <p class="handoff-body">Paste this into your agent — Claude Code, Codex, or Cursor:</p>
           <div class="handoff-cmd"><code id="handoffCmd"></code></div>
-          <button type="button" id="handoffCopy" class="btn-ghost">Copy command</button>
+          <button type="button" id="handoffCopy" class="btn-ghost">Copy prompt</button>
         </div>
         <button type="button" id="endReview" class="end-review" title="Stop this review and release the waiting agent">End review</button>
       </div>

--- a/src/editing.js
+++ b/src/editing.js
@@ -1,0 +1,61 @@
+/**
+ * Pure editing helpers, shared by the in-page SDK and Node tests.
+ *
+ * Everything here is deliberately DOM-free: the SDK feeds in strings and
+ * computed-style snapshots, and gets back decisions it can apply.
+ */
+
+/**
+ * The list command for a marker typed at the start of a line, or null.
+ * `lead` is everything between the start of the block and the caret, so a
+ * marker typed mid-sentence never converts.
+ */
+export function listCommandFor(lead) {
+  const marker = String(lead || "").replace(/\u00a0/g, " ").trim();
+  if (/^[-*]$/.test(marker)) return "insertUnorderedList";
+  if (/^\d{1,3}[.)]$/.test(marker)) return "insertOrderedList";
+  return null;
+}
+
+/**
+ * Style properties a fresh list needs when the page's CSS reset hides it.
+ * Tailwind preflight and similar resets set `list-style: none` and zero the
+ * indent, so a just-created list looks like nothing happened. Returns only
+ * the properties that are actually broken, so styled pages stay untouched.
+ */
+export function listStyleFixup(tagName, computed) {
+  const patch = {};
+  if (computed.listStyleType === "none") {
+    patch.listStyleType = /^ol$/i.test(tagName) ? "decimal" : "disc";
+  }
+  const inset = (parseFloat(computed.paddingLeft) || 0) + (parseFloat(computed.marginLeft) || 0);
+  if (inset < 16) patch.paddingLeft = "1.5em";
+  return patch;
+}
+
+/**
+ * A typed link, made openable and safe. Bare domains get https://, in-page
+ * and relative references pass through, and anything with an executable or
+ * unknown scheme (javascript:, data:, …) is rejected outright.
+ */
+export function normalizeHref(raw) {
+  const href = String(raw || "").replace(/[\u0000-\u001f\u007f]/g, "").trim();
+  if (!href) return "";
+  let candidate = href;
+  if (!/^(https?:|mailto:|tel:|#|\/|\.)/i.test(href)) {
+    const head = href.split(/[/?#]/)[0];
+    if (/^([\w-]+\.)+[\w-]+(:\d+)?$/.test(head) || /^localhost(:\d+)?$/i.test(head)) {
+      // A bare domain — "example.com", "localhost:3000/wiki" — gets a scheme.
+      candidate = `https://${href}`;
+    } else if (/^[a-z][a-z0-9+.-]*:/i.test(href)) {
+      return "";
+    }
+  }
+  try {
+    const parsed = new URL(candidate, "https://relative.invalid");
+    if (!/^(https?:|mailto:|tel:)$/i.test(parsed.protocol)) return "";
+  } catch {
+    return "";
+  }
+  return candidate;
+}

--- a/src/paths.js
+++ b/src/paths.js
@@ -5,7 +5,7 @@ import fs from "node:fs";
 
 // Bump this when the CLI and detached server no longer share the same request
 // contract. A new CLI must not silently reuse an older background server.
-export const SERVER_PROTOCOL = 6;
+export const SERVER_PROTOCOL = 7;
 
 export function stateDir() {
   const override = process.env.HUMAN_REVIEW_STATE_DIR;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -7,6 +7,7 @@
  */
 import { buildContext, findQuote } from "./anchor-text.js";
 import { navigationHref } from "./click-target.js";
+import { listCommandFor, listStyleFixup, normalizeHref } from "./editing.js";
 import { keepBodyEditable, serializeDocument, UI_ATTR, MARK_ATTR } from "./serialize.js";
 
 const SAVE_DEBOUNCE_MS = 700;
@@ -67,6 +68,16 @@ shadow.innerHTML = `
       font: 11px/1.3 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       pointer-events: none;
     }
+    .linkbox {
+      position: fixed; z-index: 2147483647; display: none; gap: 4px; align-items: center;
+      padding: 5px; border: 1px solid #e4e2db; border-radius: 9px; background: #fff;
+      box-shadow: 0 4px 16px rgba(27,26,22,.16); pointer-events: auto;
+    }
+    .linkbox input {
+      width: 224px; padding: 4px 7px; border: none; outline: none; background: none;
+      font: 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #1b1a16;
+    }
+    .linkbox input::placeholder { color: #a29f95; }
   </style>
   <div class="box outline" id="outline"></div>
   <div class="box active" id="activeBox"></div>
@@ -75,6 +86,11 @@ shadow.innerHTML = `
   </div>
   <div class="grip" id="grip" title="Drag to resize"></div>
   <div class="hint" id="hint"></div>
+  <div class="linkbox" id="linkbox">
+    <input id="linkInput" type="text" placeholder="Link to&hellip;" spellcheck="false">
+    <button class="chip" id="linkApply" title="Apply link (&#9166;)" aria-label="Apply link">&#8629;</button>
+    <button class="chip danger" id="linkRemove" title="Remove link" aria-label="Remove link">&#10005;</button>
+  </div>
 `;
 
 const els = {};
@@ -86,6 +102,10 @@ const mountOverlay = () => {
   els.chipDelete = shadow.getElementById("chipDelete");
   els.grip = shadow.getElementById("grip");
   els.hint = shadow.getElementById("hint");
+  els.linkbox = shadow.getElementById("linkbox");
+  els.linkInput = shadow.getElementById("linkInput");
+  els.linkApply = shadow.getElementById("linkApply");
+  els.linkRemove = shadow.getElementById("linkRemove");
 };
 
 function place(box, el, pad = 2) {
@@ -314,6 +334,50 @@ function targetFor(node) {
     pinnedLabels.set(block, heading ? `${clip(heading, 26)} · ${tag}${ordinal}` : clip(block.textContent, 40) || tag);
   }
   return { el: block, label: pinnedLabels.get(block), authored: false };
+}
+
+/**
+ * The nearest rendered block around a node, ignoring authored data-block
+ * containers. List conversion and drop targeting need the line the caret is
+ * actually on, not the labeled region it reports edits under.
+ */
+function innermostBlock(node) {
+  let el = node && node.nodeType === 1 ? node : node && node.parentElement;
+  while (el && el !== document.body && !isBlock(el)) el = el.parentElement;
+  return el && el !== document.body ? el : null;
+}
+
+/**
+ * After a list command: hoist the fresh list out of the paragraph Chrome
+ * sometimes nests it in (invalid HTML that a reparse would restructure), and
+ * make sure the page's CSS reset can't hide it.
+ */
+function polishNewList(sel) {
+  const node = sel && sel.anchorNode;
+  const el = node && (node.nodeType === 1 ? node : node.parentElement);
+  const item = el && el.closest ? el.closest("li") : null;
+  const list = item ? item.closest("ul, ol") : null;
+  if (!list) return;
+  const wrap = list.parentElement;
+  if (wrap && /^(p|h[1-6])$/i.test(wrap.tagName) && wrap.childNodes.length === 1) {
+    wrap.replaceWith(list);
+  }
+  const patch = listStyleFixup(list.tagName, getComputedStyle(list));
+  if (patch.listStyleType) list.style.listStyleType = patch.listStyleType;
+  if (patch.paddingLeft) list.style.paddingLeft = patch.paddingLeft;
+}
+
+/** The caret position a drag at (x, y) would drop into. */
+function caretRangeAt(x, y) {
+  if (document.caretRangeFromPoint) return document.caretRangeFromPoint(x, y);
+  if (document.caretPositionFromPoint) {
+    const pos = document.caretPositionFromPoint(x, y);
+    if (!pos) return null;
+    const range = document.createRange();
+    range.setStart(pos.offsetNode, pos.offset);
+    return range;
+  }
+  return null;
 }
 
 // ------------------------------------------------------------ serialization
@@ -656,7 +720,8 @@ function boot() {
     showChip(hoverTarget);
     showGrip(hoverMedia);
     const interactive = event.target.closest && event.target.closest("a[href], [data-href], button, [role='button']");
-    showHint(interactive ? "⌘-click to open" : "", event.clientX, event.clientY);
+    const draggable = hoverMedia && hoverMedia.tagName === "IMG";
+    showHint(interactive ? "⌘-click to open" : draggable ? "Drag to move" : "", event.clientX, event.clientY);
   });
 
   document.addEventListener("mouseleave", () => {
@@ -742,6 +807,21 @@ function boot() {
       originalHtml.set(el, blockHtml(el));
     }
   };
+
+  /** An edit row for a block changed outside the input-event flow (attribute
+   * set, link removal, drag move) — the same shape the input listener emits. */
+  const emitBlockEdit = (blockEl, fallbackLabel) => {
+    const connected = blockEl.isConnected;
+    const target = connected ? targetFor(blockEl) : null;
+    queueEdit({
+      label: (target && target.label) || fallbackLabel || "Document body",
+      kind: "edited",
+      before: originalText.get(blockEl),
+      after: connected ? blockEl.textContent : "",
+      before_html: originalHtml.get(blockEl),
+      after_html: connected ? blockHtml(blockEl) : "",
+    });
+  };
   document.addEventListener(
     "beforeinput",
     (event) => {
@@ -755,9 +835,125 @@ function boot() {
     true
   );
 
-  // ------------------------------------------------------------------ lists
+  // ------------------------------------------------------------------ links
 
-  const LIST_MARKER = /^(?:[-*]|\d+\.)$/;
+  let linkState = null; // { range, anchor, blockEl, label } while the ⌘K popup is open
+
+  function closeLinkbox(restoreSelection) {
+    if (!linkState) return;
+    const { range } = linkState;
+    linkState = null;
+    els.linkbox.style.display = "none";
+    if (restoreSelection && range) {
+      const sel = document.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+      document.body.focus({ preventScroll: true });
+    }
+  }
+
+  function openLinkbox() {
+    const sel = document.getSelection();
+    if (!sel || !sel.rangeCount) return false;
+    let range = sel.getRangeAt(0).cloneRange();
+    const container = range.commonAncestorContainer;
+    if (!document.body.contains(container) || isOurs(container)) return false;
+
+    const caretEl = container.nodeType === 1 ? container : container.parentElement;
+    const anchor = caretEl && caretEl.closest ? caretEl.closest("a") : null;
+    if (sel.isCollapsed) {
+      // A bare caret can only mean "edit the link I'm inside".
+      if (!anchor) return false;
+      range = document.createRange();
+      range.selectNodeContents(anchor);
+    }
+    const target = targetFor(anchor || container);
+    linkState = {
+      range,
+      anchor,
+      blockEl: target ? target.el : null,
+      label: target ? target.label : "Document body",
+    };
+    if (linkState.blockEl) captureOriginal(linkState.blockEl);
+
+    // The compose card and the link popup fight over the same selection.
+    clearPending();
+    post("eh:dismiss", {});
+
+    const r = range.getBoundingClientRect();
+    const below = r.bottom + 44 < window.innerHeight;
+    els.linkbox.style.display = "flex";
+    els.linkbox.style.left = `${Math.max(8, Math.min(r.left, window.innerWidth - 320))}px`;
+    els.linkbox.style.top = `${below ? r.bottom + 8 : Math.max(8, r.top - 44)}px`;
+    els.linkRemove.style.display = anchor ? "" : "none";
+    els.linkInput.value = anchor ? anchor.getAttribute("href") || "" : "";
+    els.linkInput.focus();
+    els.linkInput.select();
+    return true;
+  }
+
+  function applyLink() {
+    if (!linkState) return;
+    const href = normalizeHref(els.linkInput.value);
+    const { range, anchor, blockEl, label } = linkState;
+    if (!href) {
+      // Nothing typed → dismiss. Something unusable typed → stay open so the
+      // input isn't silently thrown away.
+      if (!els.linkInput.value.trim()) closeLinkbox(true);
+      else els.linkInput.select();
+      return;
+    }
+    userEdited = true;
+    linkState = null;
+    els.linkbox.style.display = "none";
+    if (anchor && anchor.isConnected) {
+      // Editing an existing link never rewraps — just retarget it.
+      anchor.setAttribute("href", href);
+      if (blockEl) emitBlockEdit(blockEl, label);
+    } else {
+      const sel = document.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+      document.body.focus({ preventScroll: true });
+      document.execCommand("createLink", false, href);
+    }
+    scheduleSave();
+  }
+
+  function removeLink() {
+    if (!linkState) return;
+    const { anchor, blockEl, label } = linkState;
+    linkState = null;
+    els.linkbox.style.display = "none";
+    if (!anchor || !anchor.isConnected) return;
+    userEdited = true;
+    const parent = anchor.parentNode;
+    while (anchor.firstChild) parent.insertBefore(anchor.firstChild, anchor);
+    parent.removeChild(anchor);
+    parent.normalize();
+    if (blockEl) emitBlockEdit(blockEl, label);
+    scheduleSave();
+  }
+
+  els.linkInput.addEventListener("keydown", (event) => {
+    event.stopPropagation();
+    if (event.key === "Enter") {
+      event.preventDefault();
+      applyLink();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      closeLinkbox(true);
+    }
+  });
+  els.linkApply.addEventListener("click", applyLink);
+  els.linkRemove.addEventListener("click", removeLink);
+
+  // A click anywhere in the page means the popup lost the argument.
+  document.addEventListener("pointerdown", (event) => {
+    if (linkState && !isOurs(event.target)) closeLinkbox(false);
+  });
+
+  // ------------------------------------------------------------------ lists
 
   // execCommand mutations fire `input` (so edit rows and saves flow as usual)
   // but not `beforeinput`, so originals are captured here by hand.
@@ -769,6 +965,20 @@ function boot() {
       const sel = document.getSelection();
       const anchor = sel ? sel.anchorNode : null;
 
+      // ⌘K links the selection, like Docs, Word, and Notion.
+      if (meta && !event.shiftKey && !event.altKey && (event.key === "k" || event.key === "K")) {
+        if (openLinkbox()) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+        return;
+      }
+
+      if (event.key === "Escape" && linkState) {
+        closeLinkbox(true);
+        return;
+      }
+
       // ⌘⇧8 bulleted, ⌘⇧7 numbered — the shortcuts people know from Docs.
       if (meta && event.shiftKey && (event.code === "Digit7" || event.code === "Digit8")) {
         const target = targetFor(anchor || event.target);
@@ -778,6 +988,7 @@ function boot() {
         userEdited = true;
         captureOriginal(target.el);
         document.execCommand(event.code === "Digit7" ? "insertOrderedList" : "insertUnorderedList");
+        polishNewList(document.getSelection());
         scheduleSave();
         return;
       }
@@ -793,34 +1004,144 @@ function boot() {
         const target = targetFor(item);
         if (target) captureOriginal(target.el);
         document.execCommand(event.shiftKey ? "outdent" : "indent");
+        polishNewList(document.getSelection());
         scheduleSave();
         return;
       }
 
-      // "- ", "* ", or "1. " at the start of an empty block becomes a list.
+      // "- ", "* ", "1. ", or "1) " at the start of a line becomes a list.
+      // Only the text between the block's start and the caret matters, so this
+      // works inside authored data-block containers and in front of existing
+      // text — not just in blocks that hold nothing but the marker.
       if (event.key === " " && sel && sel.isCollapsed && anchor) {
+        const host = anchor.nodeType === 1 ? anchor : anchor.parentElement;
+        if (!host || host.closest("li, ul, ol")) return;
+        const block = innermostBlock(anchor);
+        // isBlock matches display:table but not table-cell, so a caret in a
+        // table's first cell resolves the whole table — never convert that.
+        if (block && /^(table|thead|tbody|tfoot|tr)$/i.test(block.tagName)) return;
+        const lead = document.createRange();
+        // Inline content directly under <body> (a bare text node beside an
+        // image, say) has no block; the caret's own node is the line then.
+        if (block) lead.selectNodeContents(block);
+        else lead.setStart(anchor, 0);
+        try {
+          lead.setEnd(sel.anchorNode, sel.anchorOffset);
+        } catch {
+          return;
+        }
+        const command = listCommandFor(lead.toString());
+        if (!command) return;
         const target = targetFor(anchor);
-        const block = target ? target.el : null;
-        if (!block || (block.closest && block.closest("li, ul, ol"))) return;
-        const marker = block.textContent.trim();
-        if (!LIST_MARKER.test(marker)) return;
         event.preventDefault();
         event.stopPropagation();
         userEdited = true;
-        captureOriginal(block);
-        const range = document.createRange();
-        range.selectNodeContents(block);
+        if (target) captureOriginal(target.el);
         sel.removeAllRanges();
-        sel.addRange(range);
+        sel.addRange(lead);
         document.execCommand("delete");
-        document.execCommand(/^\d/.test(marker) ? "insertOrderedList" : "insertUnorderedList");
+        document.execCommand(command);
+        polishNewList(document.getSelection());
+        scheduleSave();
       }
     },
     true
   );
 
+  // ------------------------------------------------------------- image drag
+
+  // Chromium moves an image dropped inside contenteditable on its own; this
+  // code only aims the drop (indicator outline), blocks payloads that have
+  // nowhere to go (files from the desktop), and writes the edit rows for the
+  // block the image left and the block it landed in.
+  let dragging = null; // { el, fromBlock, fromLabel, overBlock, dropped } during an image drag
+
+  document.addEventListener("dragstart", (event) => {
+    const img = event.target && event.target.nodeType === 1 && event.target.tagName === "IMG" ? event.target : null;
+    if (!img || isOurs(img)) return;
+    const target = targetFor(img);
+    if (target) captureOriginal(target.el);
+    dragging = {
+      el: img,
+      src: img.src,
+      // The rendered size often comes from the container being left behind
+      // (figure/card CSS); remember it so the move can't balloon the image.
+      width: img.getBoundingClientRect().width,
+      fromBlock: target ? target.el : null,
+      fromLabel: target ? target.label : "Image",
+      overBlock: null,
+      dropped: false,
+    };
+  });
+
+  document.addEventListener("dragover", (event) => {
+    if (!dragging) {
+      // External payloads would navigate the frame or paste file:// markup.
+      if (event.dataTransfer && [...(event.dataTransfer.types || [])].includes("Files")) {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "none";
+      }
+      return;
+    }
+    const range = caretRangeAt(event.clientX, event.clientY);
+    const block = range ? innermostBlock(range.startContainer) : null;
+    if (block && !isOurs(block)) {
+      captureOriginal(block);
+      dragging.overBlock = block;
+    }
+    place(els.outline, block && !isOurs(block) ? block : null);
+  });
+
+  const finalizeImageDrag = () => {
+    const drag = dragging;
+    if (!drag || !drag.dropped) return;
+    dragging = null;
+    place(els.outline, null);
+    // Chrome re-inserts a copy on drop, so find the landed image by source,
+    // then pin it to the size it had before the move — an image dragged out
+    // of the container that was constraining it would otherwise render at
+    // its natural size.
+    let landed = drag.el.isConnected ? drag.el : null;
+    if (!landed && drag.overBlock && drag.overBlock.isConnected) {
+      landed = [...drag.overBlock.querySelectorAll("img")].find((i) => i.src === drag.src) || null;
+    }
+    if (landed && drag.width && Math.abs(landed.getBoundingClientRect().width - drag.width) > 1) {
+      landed.style.width = `${Math.round(drag.width)}px`;
+      landed.style.height = "auto";
+      landed.style.maxWidth = "100%";
+    }
+    const rows = new Map();
+    if (drag.fromBlock) rows.set(drag.fromBlock, drag.fromLabel);
+    if (drag.overBlock && !rows.has(drag.overBlock)) rows.set(drag.overBlock, null);
+    for (const [block, label] of rows) emitBlockEdit(block, label);
+    scheduleSave();
+  };
+
+  document.addEventListener("drop", (event) => {
+    if (dragging) {
+      // The move itself is the drop's default action, so the edit rows can
+      // only be read after it has run.
+      userEdited = true;
+      dragging.dropped = true;
+      setTimeout(finalizeImageDrag, 0);
+      return;
+    }
+    if (event.dataTransfer && event.dataTransfer.files && event.dataTransfer.files.length) event.preventDefault();
+  });
+
+  document.addEventListener("dragend", () => {
+    // A cancelled drag (Esc, or dropped outside the page) still needs cleanup.
+    if (dragging && !dragging.dropped) {
+      dragging = null;
+      place(els.outline, null);
+    }
+  });
+
   document.addEventListener("input", (event) => {
     if (isOurs(event.target)) return;
+    // A drop fires deleteByDrag/insertFromDrop input events whose selection
+    // points anywhere; finalizeImageDrag writes the real rows instead.
+    if (dragging) return;
     // Typing over a selection is an edit, not a comment: retire the card.
     if (pending) {
       clearPending();
@@ -846,6 +1167,8 @@ function boot() {
     place(els.outline, hoverTarget);
     showChip(hoverTarget);
     showGrip(resizing ? resizing.el : hoverMedia);
+    // The popup is viewport-fixed; scrolled away from its text it just lies.
+    if (linkState) closeLinkbox(false);
   };
   window.addEventListener("scroll", reposition, true);
   window.addEventListener("resize", reposition);

--- a/src/server.js
+++ b/src/server.js
@@ -448,7 +448,9 @@ export function createServer() {
       // --- static chrome assets
       if (route === "/chrome.css") return serveFile(res, path.join(here, "chrome.css"));
       if (route === "/chrome.js") return serveFile(res, path.join(here, "chrome-client.js"), CORS);
+      if (route === "/chrome-session.js") return serveFile(res, path.join(here, "chrome-session.js"), CORS);
       if (route === "/sdk.js") return serveFile(res, path.join(here, "sdk.js"), CORS);
+      if (route === "/editing.js") return serveFile(res, path.join(here, "editing.js"), CORS);
       if (route === "/anchor-text.js") return serveFile(res, path.join(here, "anchor-text.js"), CORS);
       if (route === "/frame-policy.js") return serveFile(res, path.join(here, "frame-policy.js"), CORS);
       if (route === "/click-target.js") return serveFile(res, path.join(here, "click-target.js"), CORS);

--- a/test/agent-loop.test.js
+++ b/test/agent-loop.test.js
@@ -7,6 +7,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import { fileURLToPath } from "node:url";
+import { SERVER_PROTOCOL } from "../src/paths.js";
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-loop-"));
 process.env.HUMAN_REVIEW_STATE_DIR = path.join(tmp, "state");
@@ -96,7 +97,7 @@ let server;
 
 test("poll --timeout exits cleanly with a timeout status", async () => {
   server = await waitForServer();
-  assert.equal(server.protocol, 6);
+  assert.equal(server.protocol, SERVER_PROTOCOL);
   const result = await collect(cli("poll", file, "--timeout", "1"));
   assert.equal(result.code, 0, result.stderr);
   const out = JSON.parse(result.stdout);

--- a/test/chrome-session.test.js
+++ b/test/chrome-session.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { pageUrl, replacePage } from "../src/chrome-session.js";
+
+test("page refreshes keep session context and clear stale cross-page counts", () => {
+  assert.equal(pageUrl("abc123", "session with spaces"), "/api/page/abc123?session=session%20with%20spaces");
+
+  const state = {
+    page: { edits: [{ label: "old" }] },
+    others: [{ key: "other", count: 60 }],
+  };
+
+  const refreshed = { key: "abc123", comments: [], edits: [], others: [] };
+  replacePage(state, refreshed);
+
+  assert.equal(state.page, refreshed);
+  assert.deepEqual(state.others, []);
+});

--- a/test/editing.test.js
+++ b/test/editing.test.js
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { listCommandFor, listStyleFixup, normalizeHref } from "../src/editing.js";
+
+test("list markers typed at the start of a line convert to the right list", () => {
+  assert.equal(listCommandFor("-"), "insertUnorderedList");
+  assert.equal(listCommandFor("*"), "insertUnorderedList");
+  assert.equal(listCommandFor("1."), "insertOrderedList");
+  assert.equal(listCommandFor("12)"), "insertOrderedList");
+  // Leading whitespace and non-breaking spaces (contenteditable loves those) don't block it.
+  assert.equal(listCommandFor("  - "), "insertUnorderedList");
+  assert.equal(listCommandFor(" -"), "insertUnorderedList");
+});
+
+test("a marker mid-sentence, or half-typed, never converts", () => {
+  assert.equal(listCommandFor("Hello -"), null);
+  assert.equal(listCommandFor("1"), null);
+  assert.equal(listCommandFor("-x"), null);
+  assert.equal(listCommandFor("2.5"), null);
+  assert.equal(listCommandFor(""), null);
+  assert.equal(listCommandFor(null), null);
+});
+
+test("a reset-hidden list gets its bullet and indent back", () => {
+  const reset = { listStyleType: "none", paddingLeft: "0px", marginLeft: "0px" };
+  assert.deepEqual(listStyleFixup("UL", reset), { listStyleType: "disc", paddingLeft: "1.5em" });
+  assert.deepEqual(listStyleFixup("OL", reset), { listStyleType: "decimal", paddingLeft: "1.5em" });
+});
+
+test("a list the page styles on purpose is left alone", () => {
+  const styled = { listStyleType: "disc", paddingLeft: "40px", marginLeft: "0px" };
+  assert.deepEqual(listStyleFixup("UL", styled), {});
+  // Custom markers with a margin-based indent count as styled too.
+  const custom = { listStyleType: "square", paddingLeft: "0px", marginLeft: "24px" };
+  assert.deepEqual(listStyleFixup("UL", custom), {});
+});
+
+test("typed links normalize to something openable", () => {
+  assert.equal(normalizeHref("example.com"), "https://example.com");
+  assert.equal(normalizeHref("www.foo.com/bar?a=1"), "https://www.foo.com/bar?a=1");
+  assert.equal(normalizeHref("localhost:3000/wiki"), "https://localhost:3000/wiki");
+  assert.equal(normalizeHref("  https://x.com  "), "https://x.com");
+  assert.equal(normalizeHref("mailto:a@b.co"), "mailto:a@b.co");
+  assert.equal(normalizeHref("tel:+15551234"), "tel:+15551234");
+});
+
+test("in-page and relative references pass through untouched", () => {
+  assert.equal(normalizeHref("#pricing"), "#pricing");
+  assert.equal(normalizeHref("/docs/setup"), "/docs/setup");
+  assert.equal(normalizeHref("./page.html"), "./page.html");
+  assert.equal(normalizeHref("docs/page.html"), "docs/page.html");
+});
+
+test("executable and unknown schemes are rejected outright", () => {
+  assert.equal(normalizeHref("javascript:alert(1)"), "");
+  assert.equal(normalizeHref("JavaScript:alert(1)"), "");
+  // Control characters can't smuggle a scheme past the check.
+  assert.equal(normalizeHref("java\tscript:alert(1)"), "");
+  assert.equal(normalizeHref("data:text/html,<script>x</script>"), "");
+  assert.equal(normalizeHref("vbscript:x"), "");
+  assert.equal(normalizeHref(""), "");
+});

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -57,6 +57,16 @@ test("the local server refuses strangers", async (t) => {
     assert.equal(res.status, 200);
   });
 
+  await t.test("browser modules imported by the review client are served", async () => {
+    const res = await request(port, { route: "/chrome-session.js" });
+    assert.equal(res.status, 200);
+    assert.match(res.raw, /export function replacePage/);
+    // sdk.js imports this at boot; if the route vanishes the editor never loads.
+    const editing = await request(port, { route: "/editing.js" });
+    assert.equal(editing.status, 200);
+    assert.match(editing.raw, /export function listCommandFor/);
+  });
+
   await t.test("a DNS-rebound host header is rejected everywhere", async () => {
     const res = await request(port, { route: "/health", headers: { host: "evil.example.com" } });
     assert.equal(res.status, 403);


### PR DESCRIPTION
## What's in here

**Lists that convert like Word** — `- `, `* `, `1. `, `1) ` convert at the start of any line: inside `data-block` containers, before existing text, and for inline content directly under `<body>`. New lists survive CSS resets (Tailwind preflight) via targeted inline fixups, and get hoisted out of the invalid `<p><ul>` nesting Chrome sometimes produces.

**⌘K link popup** — select text → ⌘K → type a URL. Bare domains get `https://`, `javascript:`/`data:` schemes rejected (control-char smuggling blocked), existing links prefill for edit/removal.

**Drag images to move them** — drop-target outline while dragging, both affected blocks emit edit rows, the image keeps its rendered size when it leaves the container that was constraining it, desktop file drops no longer navigate the frame.

**Agent-chat handoff** — the "no agent is listening" banner now hands over a paste-ready prompt for Claude Code/Codex/Cursor with the poll command embedded, instead of assuming a terminal.

Also: `chrome-session.js` page-refresh helpers extracted with tests, `SERVER_PROTOCOL` → 7 (stale detached servers can't serve the new `/editing.js` module route).

## Testing

- 9 new unit tests (marker detection, reset fixups, URL safety, session refresh); 77/77 pass.
- Verified live in-browser: list conversion in reset+data-block pages, ⌘K create/edit/remove, drag lifecycle incl. size preservation, stranded banner end-to-end.