### PR TITLE
harden: the fetchlocalpage function follows redirects f... in server.js

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -84,7 +84,11 @@ async function fetchLocalPage(target, redirects = 0) {
     const location = response.headers.get("location");
     if (!location) throw new Error(`Localhost returned redirect ${response.status} without a location.`);
     if (redirects >= MAX_LOCAL_REDIRECTS) throw new Error("Too many redirects while loading the localhost page.");
-    return fetchLocalPage(new URL(location, url).href, redirects + 1);
+    const redirectUrl = new URL(location, url);
+    if (redirectUrl.hostname !== "localhost" && redirectUrl.hostname !== "127.0.0.1") {
+      throw new Error(`Redirect target must be localhost, got: ${redirectUrl.hostname}`);
+    }
+    return fetchLocalPage(redirectUrl.href, redirects + 1);
   }
   if (!response.ok) throw new Error(`Localhost returned ${response.status} for ${url}`);
   const contentType = response.headers.get("content-type") || "";


### PR DESCRIPTION
## Summary
Harden input handling in `src/server.js` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `src/server.js:56` |
| **Assessment** | Defensive hardening |

**Description**: The fetchLocalPage function follows redirects from the localhost development server without re-validating that redirect targets remain on localhost. While initial URLs are constrained to localhost, the redirect-following logic constructs new URLs from Location headers without hostname validation, potentially allowing access to internal network services.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `src/server.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

## Security Invariant
> **Property**: The security boundary is maintained under adversarial input

<details>
<summary>Regression test</summary>

```javascript
const { fetchLocalPage } = require('../src/server');

describe("fetchLocalPage must only follow redirects to localhost", () => {
  const payloads = [
    // Exploit case: redirect to internal network
    "http://localhost:3000/redirect?to=http://192.168.1.1/admin",
    // Boundary case: redirect to localhost with different port (should be allowed)
    "http://localhost:3000/redirect?to=http://localhost:8080/internal",
    // Valid input: normal localhost URL without redirect
    "http://localhost:3000/home",
    // Exploit case: redirect with absolute URL to internal service
    "http://localhost:3000/redirect?to=http://10.0.0.1:22",
    // Boundary case: redirect with malformed URL that could bypass validation
    "http://localhost:3000/redirect?to=//evil.com",
  ];

  test.each(payloads)("rejects adversarial input: %s", async (payload) => {
    // The security property: fetchLocalPage must throw an error when redirect
    // would leave localhost, or must not return a successful response for
    // non-localhost targets.
    await expect(fetchLocalPage(payload)).rejects.toThrow(
      /localhost|Localhost|redirect|invalid|Invalid|not allowed/i
    );
  });
});
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
