### PR TITLE
Editor: block drag handles, image paste, visible ⌘K links

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Note: For HTML files, direct edits and resizes save automatically. For Markdown 
 - **Add links** — select text and press ⌘K. ⌘K inside an existing link edits or removes it.
 - **Resize images** by dragging their corner, and **move images** by dragging them to a new spot.
 - **Rearrange the page** — hover any block and drag the handle on its left edge to move the whole block somewhere else.
+- **Paste images** from your clipboard — they're saved into an `assets/` folder next to the file and inserted at your cursor.
 - **Select a phrase and leave a comment** anchored to the exact text.
 - **Comment on an image, chart, or section** by clicking the element.
 - **Remove elements** without explaining the deletion in chat.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Note: For HTML files, direct edits and resizes save automatically. For Markdown 
 - **Make bulleted and numbered lists** — type `- ` or `1. ` at the start of a line, or press ⌘⇧8 / ⌘⇧7. Tab and Shift+Tab indent and outdent.
 - **Add links** — select text and press ⌘K. ⌘K inside an existing link edits or removes it.
 - **Resize images** by dragging their corner, and **move images** by dragging them to a new spot.
+- **Rearrange the page** — hover any block and drag the handle on its left edge to move the whole block somewhere else.
 - **Select a phrase and leave a comment** anchored to the exact text.
 - **Comment on an image, chart, or section** by clicking the element.
 - **Remove elements** without explaining the deletion in chat.

--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -104,6 +104,10 @@ One batch covers every page the user visited, grouped by file or localhost URL.
   matching project source (such as MDX, TSX, or a template), apply every edit
   and deletion there, then acknowledge so the route reloads. Never write the
   rendered HTTP response back into the app.
+- When an edit's `after_html` contains `<img src="assets/...">`, the user pasted
+  an image: the file already exists in an `assets/` folder next to the reviewed
+  file. Keep that relative path — in Markdown, reference it as
+  `![](assets/...)`. Never regenerate or inline the image.
 - An edit with `kind: "moved"` means the user relocated that whole block.
   Reposition it in the source without rewriting its content: it now sits right
   after the block whose text starts with `moved_after`, and right before the

--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -104,6 +104,11 @@ One batch covers every page the user visited, grouped by file or localhost URL.
   matching project source (such as MDX, TSX, or a template), apply every edit
   and deletion there, then acknowledge so the route reloads. Never write the
   rendered HTTP response back into the app.
+- An edit with `kind: "moved"` means the user relocated that whole block.
+  Reposition it in the source without rewriting its content: it now sits right
+  after the block whose text starts with `moved_after`, and right before the
+  block whose text starts with `moved_before`. An empty `moved_after` means it
+  is now the first block in its container.
 - Find each comment by its `quote`; that exact string is in the file.
 - `kind: "element"` points at a whole block, so `quote` is its label, not body text.
 - Fix every page in `pages`, not just the first.

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -557,10 +557,27 @@ window.addEventListener("message", async (event) => {
           after: msg.after,
           before_html: msg.before_html,
           after_html: msg.after_html,
+          moved_after: msg.moved_after,
+          moved_before: msg.moved_before,
         }),
       })).page;
       state.sent = false;
       render();
+      break;
+    case "eh:asset":
+      try {
+        const saved = await fetch(`/api/page/${state.key}/asset?type=${encodeURIComponent(msg.assetType || "")}`, {
+          method: "POST",
+          headers: { "content-type": "application/octet-stream", "x-human-review-token": state.token },
+          body: msg.bytes,
+        });
+        const data = await saved.json();
+        if (!saved.ok) throw new Error(data.error || "could not save the pasted image");
+        toFrame({ type: "eh:assetSaved", id: msg.id, src: data.src });
+      } catch (err) {
+        toast(err.message);
+        toFrame({ type: "eh:assetFailed", id: msg.id });
+      }
       break;
     case "eh:saving":
       state.save = "saving";

--- a/src/editing.js
+++ b/src/editing.js
@@ -34,6 +34,18 @@ export function listStyleFixup(tagName, computed) {
 }
 
 /**
+ * Style a fresh link needs when the page can't distinguish it from prose.
+ * Reset stylesheets (`a { color: inherit; text-decoration: inherit }`) make a
+ * just-created link invisible; underline it only when neither color nor
+ * decoration sets it apart.
+ */
+export function linkStyleFixup(anchorComputed, parentComputed) {
+  const decorated = String(anchorComputed.textDecorationLine || "").includes("underline");
+  const recolored = !!parentComputed && anchorComputed.color !== parentComputed.color;
+  return decorated || recolored ? {} : { textDecoration: "underline" };
+}
+
+/**
  * A typed link, made openable and safe. Bare domains get https://, in-page
  * and relative references pass through, and anything with an executable or
  * unknown scheme (javascript:, data:, …) is rejected outright.

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -1273,6 +1273,58 @@ function boot() {
     flushSave();
   });
 
+  // ------------------------------------------------------------- image paste
+
+  // Pasted images cross to the chrome page as bytes; the server writes them
+  // into assets/ next to the reviewed file and the confirmed relative path
+  // comes back to be inserted where the caret was.
+  let pasteSeq = 0;
+  const pendingPastes = new Map(); // id → collapsed caret range to insert at
+
+  document.addEventListener(
+    "paste",
+    (event) => {
+      if (isOurs(event.target)) return;
+      const items = event.clipboardData ? [...event.clipboardData.items] : [];
+      const images = items.filter((item) => item.kind === "file" && /^image\//.test(item.type));
+      if (!images.length) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const sel = document.getSelection();
+      const caret = sel && sel.rangeCount ? sel.getRangeAt(0).cloneRange() : null;
+      for (const item of images) {
+        const file = item.getAsFile();
+        if (!file) continue;
+        pasteSeq += 1;
+        const id = `paste_${pasteSeq}`;
+        pendingPastes.set(id, caret);
+        file.arrayBuffer().then((bytes) => post("eh:asset", { id, assetType: file.type, bytes }));
+      }
+    },
+    true
+  );
+
+  const insertPastedImage = (id, src) => {
+    const caret = pendingPastes.get(id);
+    pendingPastes.delete(id);
+    userEdited = true;
+    const img = document.createElement("img");
+    img.setAttribute("src", src);
+    img.style.maxWidth = "100%";
+    const anchored = caret && caret.startContainer && document.body.contains(caret.startContainer) && !isOurs(caret.startContainer);
+    if (anchored) {
+      const target = targetFor(caret.startContainer);
+      if (target) captureOriginal(target.el);
+      caret.collapse(false);
+      caret.insertNode(img);
+    } else {
+      document.body.appendChild(img);
+    }
+    const landed = targetFor(img);
+    emitBlockEdit(landed ? landed.el : img, landed ? landed.label : "Pasted image");
+    flushSave();
+  };
+
   document.addEventListener("input", (event) => {
     if (isOurs(event.target)) return;
     // A drop fires deleteByDrag/insertFromDrop input events whose selection
@@ -1385,6 +1437,12 @@ function boot() {
         break;
       case "eh:restoreScroll":
         window.scrollTo(msg.x || 0, msg.y || 0);
+        break;
+      case "eh:assetSaved":
+        insertPastedImage(msg.id, String(msg.src || ""));
+        break;
+      case "eh:assetFailed":
+        pendingPastes.delete(msg.id);
         break;
       default:
         break;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -7,7 +7,7 @@
  */
 import { buildContext, findQuote } from "./anchor-text.js";
 import { navigationHref } from "./click-target.js";
-import { listCommandFor, listStyleFixup, normalizeHref } from "./editing.js";
+import { linkStyleFixup, listCommandFor, listStyleFixup, normalizeHref } from "./editing.js";
 import { keepBodyEditable, serializeDocument, UI_ATTR, MARK_ATTR } from "./serialize.js";
 
 const SAVE_DEBOUNCE_MS = 700;
@@ -23,6 +23,7 @@ const post = (type, payload) => parent.postMessage({ ...payload, type }, CHROME_
 
 let pending = null; // { id, marks } for an uncommitted highlight
 let hoverTarget = null;
+let hoverMove = null; // the innermost block under the cursor, movable via the handle
 let hoverMedia = null; // the img/video under the cursor, resizable via the grip
 let resizing = null; // live drag state while the grip is held
 let suppressUntil = 0; // ignore the mouseup/click that ends a resize drag
@@ -78,6 +79,20 @@ shadow.innerHTML = `
       font: 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #1b1a16;
     }
     .linkbox input::placeholder { color: #a29f95; }
+    .mover {
+      position: fixed; z-index: 2147483647; width: 18px; height: 24px;
+      display: none; align-items: center; justify-content: center;
+      border: 1px solid #e4e2db; border-radius: 6px; background: #fff; color: #a29f95;
+      font: 12px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      cursor: grab; pointer-events: auto; user-select: none;
+      box-shadow: 0 2px 8px rgba(27,26,22,.14);
+    }
+    .mover:hover { color: #1b1a16; border-color: #c2beb4; }
+    .mover:active { cursor: grabbing; }
+    .dropline {
+      position: fixed; z-index: 2147483646; height: 0; display: none;
+      border-top: 2px solid #1b1a16; border-radius: 1px; pointer-events: none;
+    }
   </style>
   <div class="box outline" id="outline"></div>
   <div class="box active" id="activeBox"></div>
@@ -91,6 +106,8 @@ shadow.innerHTML = `
     <button class="chip" id="linkApply" title="Apply link (&#9166;)" aria-label="Apply link">&#8629;</button>
     <button class="chip danger" id="linkRemove" title="Remove link" aria-label="Remove link">&#10005;</button>
   </div>
+  <div class="mover" id="mover" title="Drag to move this block">&#10303;</div>
+  <div class="dropline" id="dropline"></div>
 `;
 
 const els = {};
@@ -106,7 +123,38 @@ const mountOverlay = () => {
   els.linkInput = shadow.getElementById("linkInput");
   els.linkApply = shadow.getElementById("linkApply");
   els.linkRemove = shadow.getElementById("linkRemove");
+  els.mover = shadow.getElementById("mover");
+  els.dropline = shadow.getElementById("dropline");
 };
+
+function showMover(el) {
+  if (!el || !el.isConnected) {
+    els.mover.style.display = "none";
+    return;
+  }
+  const r = el.getBoundingClientRect();
+  if (!r.width && !r.height) {
+    els.mover.style.display = "none";
+    return;
+  }
+  els.mover.style.display = "flex";
+  // Half-overlap the block's edge: the pointer can travel from text to handle
+  // without ever leaving the block, so the hover state never drops.
+  els.mover.style.left = `${Math.max(4, r.left - 9)}px`;
+  els.mover.style.top = `${Math.max(4, r.top + 1)}px`;
+}
+
+function showDropline(drop) {
+  if (!drop || !drop.ref.isConnected) {
+    els.dropline.style.display = "none";
+    return;
+  }
+  const r = drop.ref.getBoundingClientRect();
+  els.dropline.style.display = "block";
+  els.dropline.style.left = `${r.left}px`;
+  els.dropline.style.width = `${r.width}px`;
+  els.dropline.style.top = `${(drop.before ? r.top : r.bottom) - 1}px`;
+}
 
 function place(box, el, pad = 2) {
   if (!el || !el.isConnected) {
@@ -712,12 +760,16 @@ function boot() {
   }, true);
 
   document.addEventListener("mouseover", (event) => {
-    if (isOurs(event.target) || resizing) return;
+    if (isOurs(event.target) || resizing || moving) return;
     const target = targetFor(event.target);
     hoverTarget = target ? target.el : null;
+    // The move handle works per element, not per labeled container, so each
+    // paragraph inside a card can travel on its own.
+    hoverMove = hoverTarget ? innermostBlock(event.target) || hoverTarget : null;
     hoverMedia = event.target.closest ? event.target.closest("img, video") : null;
     place(els.outline, hoverTarget);
     showChip(hoverTarget);
+    showMover(hoverMove);
     showGrip(hoverMedia);
     const interactive = event.target.closest && event.target.closest("a[href], [data-href], button, [role='button']");
     const draggable = hoverMedia && hoverMedia.tagName === "IMG";
@@ -725,11 +777,13 @@ function boot() {
   });
 
   document.addEventListener("mouseleave", () => {
-    if (resizing) return;
+    if (resizing || moving) return;
     hoverTarget = null;
+    hoverMove = null;
     hoverMedia = null;
     place(els.outline, null);
     showChip(null);
+    showMover(null);
     showGrip(null);
     showHint("");
   });
@@ -916,6 +970,18 @@ function boot() {
       sel.addRange(range);
       document.body.focus({ preventScroll: true });
       document.execCommand("createLink", false, href);
+      // On pages that reset anchor styling the new link looks like plain
+      // prose — underline it so the user sees that it took.
+      const node = sel.anchorNode;
+      const el = node && (node.nodeType === 1 ? node : node.parentElement);
+      const created = el && el.closest ? el.closest("a") : null;
+      if (created) {
+        const patch = linkStyleFixup(
+          getComputedStyle(created),
+          created.parentElement ? getComputedStyle(created.parentElement) : null
+        );
+        if (patch.textDecoration) created.style.textDecoration = patch.textDecoration;
+      }
     }
     scheduleSave();
   }
@@ -1137,6 +1203,76 @@ function boot() {
     }
   });
 
+  // ------------------------------------------------------------- block moves
+
+  // The handle on a block's left edge moves the whole block. Pointer-based,
+  // not HTML5 drag: the element is relocated on drop, never cloned, so
+  // identity (labels, captured originals, comment anchors) survives the move.
+  let moving = null; // { el, label, drop: { ref, before } | null } while the handle is held
+
+  const dropPointFor = (x, y) => {
+    const under = document.elementFromPoint(x, y);
+    if (!under || isOurs(under)) return null;
+    const block = innermostBlock(under);
+    if (!block || block === moving.el || moving.el.contains(block)) return null;
+    const r = block.getBoundingClientRect();
+    return { ref: block, before: y < r.top + r.height / 2 };
+  };
+
+  els.mover.addEventListener("pointerdown", (event) => {
+    const el = hoverMove && hoverMove.isConnected ? hoverMove : hoverTarget;
+    if (!el || !el.isConnected) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const target = targetFor(el);
+    moving = { el, label: target ? target.label : "Block", drop: null };
+    captureOriginal(moving.el);
+    moving.el.style.opacity = "0.4";
+    place(els.outline, null);
+    showChip(null);
+    try {
+      els.mover.setPointerCapture(event.pointerId);
+    } catch {
+      // Window-level listeners track the move even without capture.
+    }
+  });
+
+  window.addEventListener("pointermove", (event) => {
+    if (!moving) return;
+    event.preventDefault();
+    moving.drop = dropPointFor(event.clientX, event.clientY);
+    showDropline(moving.drop);
+  });
+
+  window.addEventListener("pointerup", () => {
+    if (!moving) return;
+    const { el, label, drop } = moving;
+    moving = null;
+    showDropline(null);
+    showMover(null);
+    el.style.opacity = "";
+    suppressUntil = Date.now() + 250;
+    if (!drop || !drop.ref.isConnected || !el.isConnected) return;
+    // Dropping right back where it came from is a no-op, not an edit.
+    const next = drop.before ? drop.ref : drop.ref.nextElementSibling;
+    if (next === el || (drop.before ? drop.ref.previousElementSibling : drop.ref) === el) return;
+    userEdited = true;
+    drop.ref.parentNode.insertBefore(el, next);
+    const prev = el.previousElementSibling;
+    const following = el.nextElementSibling;
+    queueEdit({
+      label,
+      kind: "moved",
+      before: originalText.get(el),
+      after: el.textContent,
+      before_html: originalHtml.get(el),
+      after_html: blockHtml(el),
+      moved_after: prev ? clip(prev.textContent, 90) : "",
+      moved_before: following ? clip(following.textContent, 90) : "",
+    });
+    flushSave();
+  });
+
   document.addEventListener("input", (event) => {
     if (isOurs(event.target)) return;
     // A drop fires deleteByDrag/insertFromDrop input events whose selection
@@ -1166,12 +1302,24 @@ function boot() {
   const reposition = () => {
     place(els.outline, hoverTarget);
     showChip(hoverTarget);
+    showMover(moving ? null : hoverMove);
     showGrip(resizing ? resizing.el : hoverMedia);
     // The popup is viewport-fixed; scrolled away from its text it just lies.
     if (linkState) closeLinkbox(false);
   };
-  window.addEventListener("scroll", reposition, true);
-  window.addEventListener("resize", reposition);
+  // getBoundingClientRect on every scroll event forces layout mid-scroll;
+  // one reposition per frame is plenty.
+  let repositionQueued = false;
+  const scheduleReposition = () => {
+    if (repositionQueued) return;
+    repositionQueued = true;
+    requestAnimationFrame(() => {
+      repositionQueued = false;
+      reposition();
+    });
+  };
+  window.addEventListener("scroll", scheduleReposition, true);
+  window.addEventListener("resize", scheduleReposition);
 
   let scrollQueued = false;
   window.addEventListener(

--- a/src/server.js
+++ b/src/server.js
@@ -633,9 +633,11 @@ export function createServer() {
         if (action === "edit" && req.method === "POST") {
           const body = await readBody(req);
           const label = String(body.label || "Document");
-          const kind = body.kind === "deleted" ? "deleted" : "edited";
+          const kind = body.kind === "deleted" ? "deleted" : body.kind === "moved" ? "moved" : "edited";
           const cap = (s) => (typeof s === "string" ? s.slice(0, 4000) : undefined);
-          store.addEdit(key, label, kind, cap(body.before), cap(body.after), cap(body.before_html), cap(body.after_html));
+          const extra =
+            kind === "moved" ? { moved_after: cap(body.moved_after) || "", moved_before: cap(body.moved_before) || "" } : undefined;
+          store.addEdit(key, label, kind, cap(body.before), cap(body.after), cap(body.before_html), cap(body.after_html), extra);
           return json(res, 200, { page: pageState(key) });
         }
 

--- a/src/server.js
+++ b/src/server.js
@@ -368,6 +368,25 @@ export function createServer() {
     });
   }
 
+  /** Binary request body (pasted images), capped like readBody. */
+  function readRawBody(req) {
+    return new Promise((resolve, reject) => {
+      let size = 0;
+      const chunks = [];
+      req.on("data", (chunk) => {
+        size += chunk.length;
+        if (size > MAX_BODY) {
+          reject(new Error("body too large"));
+          req.destroy();
+          return;
+        }
+        chunks.push(chunk);
+      });
+      req.on("end", () => resolve(Buffer.concat(chunks)));
+      req.on("error", reject);
+    });
+  }
+
   const json = (res, code, payload) => {
     res.writeHead(code, { "content-type": "application/json; charset=utf-8" });
     res.end(JSON.stringify(payload));
@@ -639,6 +658,33 @@ export function createServer() {
             kind === "moved" ? { moved_after: cap(body.moved_after) || "", moved_before: cap(body.moved_before) || "" } : undefined;
           store.addEdit(key, label, kind, cap(body.before), cap(body.after), cap(body.before_html), cap(body.after_html), extra);
           return json(res, 200, { page: pageState(key) });
+        }
+
+        // A pasted image: write it next to the reviewed file so the relative
+        // src resolves in the review, in the saved file, and for the agent.
+        if (action === "asset" && req.method === "POST") {
+          const page = store.page(key);
+          if (page.kind === "url") {
+            return json(res, 400, { error: "Pasting images works on file reviews — for localhost pages, add the image to the app source." });
+          }
+          const type = String(url.searchParams.get("type") || "");
+          const ext = { "image/png": "png", "image/jpeg": "jpg", "image/gif": "gif", "image/webp": "webp" }[type];
+          if (!ext) return json(res, 400, { error: `unsupported image type: ${type || "unknown"}` });
+          const bytes = await readRawBody(req);
+          if (!bytes.length) return json(res, 400, { error: "empty image" });
+          const dir = path.join(path.dirname(page.file), "assets");
+          fs.mkdirSync(dir, { recursive: true });
+          const base = path
+            .basename(page.file)
+            .replace(/\.[^.]+$/, "")
+            .replace(/[^\w-]+/g, "-");
+          let name = "";
+          for (let n = 1; ; n += 1) {
+            name = `${base}-paste-${n}.${ext}`;
+            if (!fs.existsSync(path.join(dir, name))) break;
+          }
+          fs.writeFileSync(path.join(dir, name), bytes);
+          return json(res, 200, { src: `assets/${name}` });
         }
 
         if (action === "save" && req.method === "POST") {

--- a/src/state.js
+++ b/src/state.js
@@ -206,16 +206,18 @@ export class Store {
    * Edits are deduped by label+kind so retyping one block stays one row, but
    * the text is refreshed every time so `after` is always the latest wording.
    */
-  addEdit(key, label, kind, before, after, beforeHtml, afterHtml) {
+  addEdit(key, label, kind, before, after, beforeHtml, afterHtml, extra) {
     return this.update(key, (page) => {
       const row = page.edits.find((e) => e.label === label && e.kind === kind);
       if (row) {
         if (after !== undefined) row.after = after;
         if (afterHtml !== undefined) row.after_html = afterHtml;
+        // A re-move of the same block replaces its landing spot.
+        if (extra) Object.assign(row, extra);
         row.updatedAt = Date.now();
         return;
       }
-      page.edits.push({ label, kind, before, after, before_html: beforeHtml, after_html: afterHtml, at: Date.now(), updatedAt: Date.now() });
+      page.edits.push({ label, kind, before, after, before_html: beforeHtml, after_html: afterHtml, ...(extra || {}), at: Date.now(), updatedAt: Date.now() });
     });
   }
 

--- a/test/asset-paste.test.js
+++ b/test/asset-paste.test.js
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-paste-"));
+process.env.HUMAN_REVIEW_STATE_DIR = path.join(tmp, "state");
+
+const { start } = await import("../src/server.js");
+
+function request(port, { method = "GET", route = "/", headers = {}, body = null } = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, method, path: route, headers }, (res) => {
+      let raw = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        raw += chunk;
+      });
+      res.on("end", () => resolve({ status: res.statusCode, raw }));
+    });
+    req.on("error", reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+// A 1x1 transparent PNG.
+const PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+  "base64"
+);
+
+test("pasted images land in assets/ next to the reviewed file", async (t) => {
+  const { port, token, dispose } = await start();
+  t.after(() => dispose());
+
+  const file = path.join(tmp, "My Spec.html");
+  fs.writeFileSync(file, "<!doctype html><html><body><p>Hi</p></body></html>");
+  const opened = JSON.parse(
+    (
+      await request(port, {
+        method: "POST",
+        route: "/api/session",
+        headers: { "x-human-review-token": token, "content-type": "application/json" },
+        body: JSON.stringify({ file }),
+      })
+    ).raw
+  );
+  const key = JSON.parse(
+    (
+      await request(port, {
+        route: `/api/session/${opened.sessionId}/page`,
+        headers: { "x-human-review-token": token },
+      })
+    ).raw
+  ).page.key;
+
+  await t.test("a png is written and its relative src returned", async () => {
+    const res = await request(port, {
+      method: "POST",
+      route: `/api/page/${key}/asset?type=${encodeURIComponent("image/png")}`,
+      headers: { "x-human-review-token": token, "content-type": "application/octet-stream" },
+      body: PNG,
+    });
+    assert.equal(res.status, 200);
+    const { src } = JSON.parse(res.raw);
+    assert.equal(src, "assets/My-Spec-paste-1.png");
+    const written = fs.readFileSync(path.join(tmp, "assets", "My-Spec-paste-1.png"));
+    assert.deepEqual(written, PNG);
+  });
+
+  await t.test("a second paste never overwrites the first", async () => {
+    const res = await request(port, {
+      method: "POST",
+      route: `/api/page/${key}/asset?type=${encodeURIComponent("image/png")}`,
+      headers: { "x-human-review-token": token, "content-type": "application/octet-stream" },
+      body: PNG,
+    });
+    assert.equal(JSON.parse(res.raw).src, "assets/My-Spec-paste-2.png");
+  });
+
+  await t.test("non-image types are refused", async () => {
+    const res = await request(port, {
+      method: "POST",
+      route: `/api/page/${key}/asset?type=${encodeURIComponent("image/svg+xml")}`,
+      headers: { "x-human-review-token": token, "content-type": "application/octet-stream" },
+      body: Buffer.from("<svg onload=alert(1)></svg>"),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  await t.test("a moved edit keeps its landing-spot fields through the API", async () => {
+    const res = await request(port, {
+      method: "POST",
+      route: `/api/page/${key}/edit`,
+      headers: { "x-human-review-token": token, "content-type": "application/json" },
+      body: JSON.stringify({
+        label: "Hi block",
+        kind: "moved",
+        before: "Hi",
+        after: "Hi",
+        moved_after: "Intro paragraph",
+        moved_before: "Closing paragraph",
+      }),
+    });
+    assert.equal(res.status, 200);
+    const row = JSON.parse(res.raw).page.edits.find((e) => e.kind === "moved");
+    assert.equal(row.moved_after, "Intro paragraph");
+    assert.equal(row.moved_before, "Closing paragraph");
+  });
+});

--- a/test/editing.test.js
+++ b/test/editing.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { listCommandFor, listStyleFixup, normalizeHref } from "../src/editing.js";
+import { linkStyleFixup, listCommandFor, listStyleFixup, normalizeHref } from "../src/editing.js";
 
 test("list markers typed at the start of a line convert to the right list", () => {
   assert.equal(listCommandFor("-"), "insertUnorderedList");
@@ -50,6 +50,18 @@ test("in-page and relative references pass through untouched", () => {
   assert.equal(normalizeHref("/docs/setup"), "/docs/setup");
   assert.equal(normalizeHref("./page.html"), "./page.html");
   assert.equal(normalizeHref("docs/page.html"), "docs/page.html");
+});
+
+test("a link the page renders as plain prose gets an underline", () => {
+  const prose = { color: "rgb(34, 34, 34)" };
+  const resetLink = { textDecorationLine: "none", color: "rgb(34, 34, 34)" };
+  assert.deepEqual(linkStyleFixup(resetLink, prose), { textDecoration: "underline" });
+});
+
+test("a link the page already styles is left alone", () => {
+  const prose = { color: "rgb(34, 34, 34)" };
+  assert.deepEqual(linkStyleFixup({ textDecorationLine: "underline", color: "rgb(34, 34, 34)" }, prose), {});
+  assert.deepEqual(linkStyleFixup({ textDecorationLine: "none", color: "rgb(41, 95, 204)" }, prose), {});
 });
 
 test("executable and unknown schemes are rejected outright", () => {


### PR DESCRIPTION
## What's in here

**Block drag handles** — hover any block and a grip handle appears half-overlapping its left edge; drag it to move the whole block, with an insertion line showing the landing spot. Works per innermost block, so paragraphs inside authored containers travel on their own. Moves reach agents as a new `kind: "moved"` edit with `moved_after`/`moved_before` anchors, documented in SKILL.md.

**Image paste** — pasting writes the image into `assets/` next to the reviewed file via a new token-authed `/asset` route (png/jpeg/gif/webp only, collision-safe naming), inserts it at the caret, and SKILL.md teaches agents to keep the relative reference. Localhost pages get a clear error.

**⌘K links you can see** — links created on pages that reset anchor styling were invisible; they now get an inline underline only when the page gives them no distinguishing color or decoration.

**Perf** — overlay repositioning is now once-per-frame instead of per scroll event (from the GPU report).

Also fixes the chrome relay dropping `moved_after`/`moved_before` from edit rows.

## Testing
84/84 tests pass, including 5 new ones (asset upload, collision naming, type rejection, moved-kind API round-trip). Drag lifecycle, underline fixup, and handle hover verified live in-browser.