### PR TITLE
v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "human-review",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "human-review",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "marked": "^18.0.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "human-review",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Review and edit agent-generated files and localhost pages in the browser, then send the whole batch back to your agent.",
   "author": "Peter Yang",
   "homepage": "https://github.com/petergyang/human-review#readme",


### PR DESCRIPTION
Version bump: block drag handles, image paste, visible ⌘K links, Windows console-flash fix (#8), hash-link navigation + note-only sends (#11).