### PR TITLE
Fix: don't submit comment on IME composition Enter key

### DIFF
--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -8,6 +8,14 @@ import { tidy } from "./anchor-text.js";
 import { pageUrl, replacePage } from "./chrome-session.js";
 import { framePolicy } from "./frame-policy.js";
 
+/**
+ * True when an "Enter" keydown is really an IME confirming its composition
+ * (e.g. finalizing kanji conversion), not the user asking to submit.
+ */
+function isImeCommitEnter(event) {
+  return Boolean(event.isComposing || event.keyCode === 229);
+}
+
 const $ = (id) => document.getElementById(id);
 const frame = $("frame");
 
@@ -392,6 +400,7 @@ function editComment(card, body, comment) {
   input.addEventListener("keydown", (event) => {
     event.stopPropagation();
     if (event.key === "Enter" && !event.shiftKey) {
+      if (isImeCommitEnter(event)) return;
       event.preventDefault();
       commit();
     }
@@ -640,6 +649,7 @@ $("compose").addEventListener("mousedown", (event) => {
 
 $("composeText").addEventListener("keydown", (event) => {
   if (event.key === "Enter" && !event.shiftKey) {
+    if (isImeCommitEnter(event)) return;
     event.preventDefault();
     commitCompose();
   }
@@ -764,6 +774,7 @@ function applyTheme(dark) {
 document.addEventListener("keydown", (event) => {
   const meta = event.metaKey || event.ctrlKey;
   if (meta && event.key === "Enter") {
+    if (isImeCommitEnter(event)) return;
     event.preventDefault();
     if (!$("send").disabled) $("send").click();
     return;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -10,6 +10,14 @@ import { hashClickAction, navigationHref } from "./click-target.js";
 import { linkStyleFixup, listCommandFor, listStyleFixup, normalizeHref } from "./editing.js";
 import { keepBodyEditable, serializeDocument, UI_ATTR, MARK_ATTR } from "./serialize.js";
 
+/**
+ * True when an "Enter" keydown is really an IME confirming its composition
+ * (e.g. finalizing kanji conversion), not the user asking to submit.
+ */
+function isImeCommitEnter(event) {
+  return Boolean(event.isComposing || event.keyCode === 229);
+}
+
 const SAVE_DEBOUNCE_MS = 700;
 const EDIT_FLUSH_MS = 500;
 const MEDIA = /^(img|svg|canvas|video|picture|iframe|hr|figure)$/i;
@@ -1012,6 +1020,7 @@ function boot() {
   els.linkInput.addEventListener("keydown", (event) => {
     event.stopPropagation();
     if (event.key === "Enter") {
+      if (isImeCommitEnter(event)) return;
       event.preventDefault();
       applyLink();
     } else if (event.key === "Escape") {


### PR DESCRIPTION
## Problem

Every Enter-key handler that submits a comment treated a bare Enter as "submit," with no check for whether an IME composition was in progress. Japanese/CJK users pressing Enter to confirm kanji conversion had their in-progress comment submitted prematurely instead of just confirming the conversion.

This affected:
- The comment composer (`#composeText` in `chrome-client.js`)
- Inline comment editing (`editComment` in `chrome-client.js`)
- The Cmd/Ctrl+Enter send-batch shortcut (`chrome-client.js`)
- The artifact SDK's link-input Enter-to-apply handler (`sdk.js`)

## Fix

Added a small `isImeCommitEnter(event)` guard (`event.isComposing || event.keyCode === 229`) before each handler's submit action, so a composition-confirming Enter no longer triggers `preventDefault()` or the submit action.

## Testing

- `npm test` — all existing tests pass, no regressions
- Manually verified in a browser (Safari): typing Japanese text and confirming kanji conversion with Enter no longer submits the comment; a normal Enter still submits as before