### PR TITLE
Support localhost image pastes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Note: For HTML files, direct edits and resizes save automatically. For Markdown 
 - **Add links** — select text and press ⌘K. ⌘K inside an existing link edits or removes it.
 - **Resize images** by dragging their corner, and **move images** by dragging them to a new spot.
 - **Rearrange the page** — hover any block and drag the handle on its left edge to move the whole block somewhere else.
-- **Paste images** from your clipboard — they're saved into an `assets/` folder next to the file and inserted at your cursor.
+- **Paste images** from your clipboard — file reviews save them beside the document; localhost reviews stage them for the agent to place in the app source.
 - **Select a phrase and leave a comment** anchored to the exact text.
 - **Comment on an image, chart, or section** by clicking the element.
 - **Remove elements** without explaining the deletion in chat.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "human-review",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "human-review",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "marked": "^18.0.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "human-review",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Review and edit agent-generated files and localhost pages in the browser, then send the whole batch back to your agent.",
   "author": "Peter Yang",
   "homepage": "https://github.com/petergyang/human-review#readme",

--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -108,6 +108,10 @@ One batch covers every page the user visited, grouped by file or localhost URL.
   an image: the file already exists in an `assets/` folder next to the reviewed
   file. Keep that relative path — in Markdown, reference it as
   `![](assets/...)`. Never regenerate or inline the image.
+- On a localhost page, a pasted image arrives under `staged_assets`. Copy its
+  local `path` into the app's appropriate asset folder, replace the temporary
+  preview URL in `after_html`, and preserve the image at the user's insertion
+  point. Never leave the temporary preview URL in source.
 - An edit with `kind: "moved"` means the user relocated that whole block.
   Reposition it in the source without rewriting its content: it now sits right
   after the block whose text starts with `moved_after`, and right before the

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -564,6 +564,7 @@ window.addEventListener("message", async (event) => {
           after_html: msg.after_html,
           moved_after: msg.moved_after,
           moved_before: msg.moved_before,
+          staged_assets: msg.staged_assets,
         }),
       })).page;
       state.sent = false;
@@ -578,7 +579,7 @@ window.addEventListener("message", async (event) => {
         });
         const data = await saved.json();
         if (!saved.ok) throw new Error(data.error || "could not save the pasted image");
-        toFrame({ type: "eh:assetSaved", id: msg.id, src: data.src });
+        toFrame({ type: "eh:assetSaved", id: msg.id, src: data.src, stagedId: data.stagedId });
       } catch (err) {
         toast(err.message);
         toFrame({ type: "eh:assetFailed", id: msg.id });

--- a/src/paths.js
+++ b/src/paths.js
@@ -5,7 +5,7 @@ import fs from "node:fs";
 
 // Bump this when the CLI and detached server no longer share the same request
 // contract. A new CLI must not silently reuse an older background server.
-export const SERVER_PROTOCOL = 7;
+export const SERVER_PROTOCOL = 8;
 
 export function stateDir() {
   const override = process.env.HUMAN_REVIEW_STATE_DIR;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -57,6 +57,8 @@ shadow.innerHTML = `
     .chip:hover { background: #1b1a16; color: #fff; border-color: #1b1a16; }
     .chip.danger { color: #b23b2e; }
     .chip.danger:hover { background: #b23b2e; color: #fff; border-color: #b23b2e; }
+    .chips .chip, .mover { opacity: .6; transition: opacity 100ms ease; }
+    .chips .chip:hover, .chips .chip:focus-visible, .mover:hover, .mover:focus-visible { opacity: 1; }
     .grip {
       position: fixed; z-index: 2147483647; width: 13px; height: 13px;
       display: none; border: 1px solid #1b1a16; border-radius: 3px;
@@ -549,7 +551,13 @@ function flushEdits() {
 }
 
 function queueEdit(payload) {
-  editQueue.set(`${payload.label}\u0000${payload.kind}`, payload);
+  const key = `${payload.label}\u0000${payload.kind}`;
+  const queued = editQueue.get(key);
+  if (queued && (queued.staged_assets || payload.staged_assets)) {
+    const assets = [...(queued.staged_assets || []), ...(payload.staged_assets || [])];
+    payload.staged_assets = [...new Map(assets.map((asset) => [asset.path || asset.id, asset])).values()];
+  }
+  editQueue.set(key, payload);
   clearTimeout(editTimer);
   editTimer = setTimeout(flushEdits, EDIT_FLUSH_MS);
 }
@@ -776,8 +784,11 @@ function boot() {
     hoverMove = hoverTarget ? innermostBlock(event.target) || hoverTarget : null;
     hoverMedia = event.target.closest ? event.target.closest("img, video") : null;
     place(els.outline, hoverTarget);
-    showChip(hoverTarget);
-    showMover(hoverMove);
+    if (controlsAreSuppressed()) hideActionControls();
+    else {
+      showChip(hoverTarget);
+      showMover(hoverMove);
+    }
     showGrip(hoverMedia);
     const interactive = event.target.closest && event.target.closest("a[href], [data-href], button, [role='button']");
     const draggable = hoverMedia && hoverMedia.tagName === "IMG";
@@ -872,7 +883,7 @@ function boot() {
 
   /** An edit row for a block changed outside the input-event flow (attribute
    * set, link removal, drag move) — the same shape the input listener emits. */
-  const emitBlockEdit = (blockEl, fallbackLabel) => {
+  const emitBlockEdit = (blockEl, fallbackLabel, extra = {}) => {
     const connected = blockEl.isConnected;
     const target = connected ? targetFor(blockEl) : null;
     queueEdit({
@@ -882,12 +893,42 @@ function boot() {
       after: connected ? blockEl.textContent : "",
       before_html: originalHtml.get(blockEl),
       after_html: connected ? blockHtml(blockEl) : "",
+      ...extra,
     });
+  };
+
+  let typingUntil = 0;
+  let controlRestoreTimer = null;
+
+  const selectionIsActive = () => {
+    const sel = document.getSelection();
+    return !!(sel && !sel.isCollapsed && sel.rangeCount && document.body.contains(sel.getRangeAt(0).commonAncestorContainer));
+  };
+
+  const controlsAreSuppressed = () => Date.now() < typingUntil || selectionIsActive();
+
+  const hideActionControls = () => {
+    showChip(null);
+    showMover(null);
+  };
+
+  const restoreActionControls = () => {
+    if (controlsAreSuppressed()) return;
+    showChip(hoverTarget);
+    showMover(hoverMove);
+  };
+
+  const suppressActionControlsWhileTyping = () => {
+    typingUntil = Date.now() + 800;
+    hideActionControls();
+    clearTimeout(controlRestoreTimer);
+    controlRestoreTimer = setTimeout(restoreActionControls, 810);
   };
   document.addEventListener(
     "beforeinput",
     (event) => {
       if (isOurs(event.target)) return;
+      suppressActionControlsWhileTyping();
       // From here on, DOM drift is the human typing, not the page rendering.
       userEdited = true;
       const sel = document.getSelection();
@@ -896,6 +937,11 @@ function boot() {
     },
     true
   );
+
+  document.addEventListener("selectionchange", () => {
+    if (selectionIsActive()) hideActionControls();
+    else restoreActionControls();
+  });
 
   // ------------------------------------------------------------------ links
 
@@ -1312,7 +1358,7 @@ function boot() {
     true
   );
 
-  const insertPastedImage = (id, src) => {
+  const insertPastedImage = (id, src, stagedId) => {
     const caret = pendingPastes.get(id);
     pendingPastes.delete(id);
     userEdited = true;
@@ -1329,7 +1375,9 @@ function boot() {
       document.body.appendChild(img);
     }
     const landed = targetFor(img);
-    emitBlockEdit(landed ? landed.el : img, landed ? landed.label : "Pasted image");
+    emitBlockEdit(landed ? landed.el : img, landed ? landed.label : "Pasted image", {
+      ...(stagedId ? { staged_assets: [{ id: stagedId, preview_src: src }] } : {}),
+    });
     flushSave();
   };
 
@@ -1447,7 +1495,7 @@ function boot() {
         window.scrollTo(msg.x || 0, msg.y || 0);
         break;
       case "eh:assetSaved":
-        insertPastedImage(msg.id, String(msg.src || ""));
+        insertPastedImage(msg.id, String(msg.src || ""), String(msg.stagedId || ""));
         break;
       case "eh:assetFailed":
         pendingPastes.delete(msg.id);

--- a/src/server.js
+++ b/src/server.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { atomicWrite, Store, resolveAsset } from "./state.js";
 import { injectSdk, stripSdk } from "./html-transform.js";
 import { isMarkdown, renderMarkdownPage } from "./markdown.js";
-import { canonicalTarget, ensureStateDir, localUrl, SERVER_PROTOCOL, serverPath, targetKey } from "./paths.js";
+import { canonicalTarget, ensureStateDir, localUrl, SERVER_PROTOCOL, serverPath, stateDir, targetKey } from "./paths.js";
 import { invocation, shellQuote } from "./setup.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -230,6 +230,7 @@ export function createServer() {
           after: e.after,
           ...(e.before_html !== undefined && e.before_html !== e.before ? { before_html: e.before_html } : {}),
           ...(e.after_html !== undefined && e.after_html !== e.after ? { after_html: e.after_html } : {}),
+          ...(Array.isArray(e.staged_assets) && e.staged_assets.length ? { staged_assets: e.staged_assets } : {}),
         })),
       });
     }
@@ -272,7 +273,9 @@ export function createServer() {
           : "") +
         (hasUrl
           ? "Localhost pages were edited directly in the review UI. Find the matching project source (such as MDX or TSX) " +
-            "and apply every exact edit or deletion there; never try to write the rendered HTML response back to the app. "
+            "and apply every exact edit or deletion there; never try to write the rendered HTML response back to the app. " +
+            "When an edit includes `staged_assets`, copy each local image into the app's appropriate asset folder, replace its " +
+            "temporary preview URL in `after_html`, and preserve the image at the user's insertion point. "
           : "") +
         "When every page is updated, run the same poll command again with --ack to clear this " +
         "batch and wait for more.",
@@ -281,7 +284,12 @@ export function createServer() {
     const record = {
       batch,
       delivered: false,
-      cleanup: pages.map((p) => ({ key: p.key, ids: p.comments.map((c) => c.id), sentAt: Date.now() })),
+      cleanup: pages.map((p) => ({
+        key: p.key,
+        ids: p.comments.map((c) => c.id),
+        staged: p.edits.flatMap((edit) => (edit.staged_assets || []).map((asset) => asset.path)),
+        sentAt: Date.now(),
+      })),
     };
     batches.set(session.entryKey, record);
     store.setBatch(session.entryKey, record);
@@ -298,6 +306,16 @@ export function createServer() {
     if (!pending || !pending.delivered) return false;
     batches.delete(entryKey);
     store.clearBatch(entryKey);
+    const stagedRoot = path.join(stateDir(), "pasted");
+    for (const file of pending.cleanup.flatMap((entry) => entry.staged || [])) {
+      const resolved = path.resolve(file);
+      const relative = path.relative(stagedRoot, resolved);
+      if (relative.startsWith("..") || path.isAbsolute(relative)) continue;
+      try {
+        fs.unlinkSync(resolved);
+        fs.rmdirSync(path.dirname(resolved));
+      } catch {}
+    }
     for (const { key, ids, sentAt } of pending.cleanup) store.clearSent(key, ids, sentAt);
     for (const session of sessionsForEntry(entryKey)) emit(session, "refresh", {});
     // File targets reload through fs.watch. URL targets have no source file to
@@ -550,6 +568,15 @@ export function createServer() {
           return res.end(injectSdk(html, key, sdkOptions));
         }
         if (page.kind === "url") {
+          const stagedPrefix = "__human_review_paste__/";
+          if (asset.startsWith(stagedPrefix)) {
+            const name = asset.slice(stagedPrefix.length);
+            if (!name || path.basename(name) !== name) {
+              res.writeHead(403, { "content-type": "text/plain" });
+              return res.end("Forbidden");
+            }
+            return serveFile(res, path.join(stateDir(), "pasted", key, name));
+          }
           res.writeHead(404, { "content-type": "text/plain" });
           return res.end("Localhost assets load from the reviewed development server.");
         }
@@ -655,37 +682,61 @@ export function createServer() {
           const label = String(body.label || "Document");
           const kind = body.kind === "deleted" ? "deleted" : body.kind === "moved" ? "moved" : "edited";
           const cap = (s) => (typeof s === "string" ? s.slice(0, 4000) : undefined);
-          const extra =
-            kind === "moved" ? { moved_after: cap(body.moved_after) || "", moved_before: cap(body.moved_before) || "" } : undefined;
+          const stagedRoot = path.join(stateDir(), "pasted", key);
+          const stagedAssets = Array.isArray(body.staged_assets)
+            ? body.staged_assets
+                .slice(0, 20)
+                .map((asset) => {
+                  const id = String(asset?.id || "");
+                  return {
+                    id,
+                    path: path.join(stagedRoot, id),
+                    preview_src: String(asset?.preview_src || ""),
+                  };
+                })
+                .filter((asset) => {
+                  const relative = path.relative(stagedRoot, path.resolve(asset.path));
+                  return asset.id && path.basename(asset.id) === asset.id && !relative.startsWith("..") && !path.isAbsolute(relative) && fs.existsSync(asset.path);
+                })
+                .map(({ path: assetPath, preview_src }) => ({ path: assetPath, preview_src }))
+            : [];
+          const extra = {
+            ...(kind === "moved" ? { moved_after: cap(body.moved_after) || "", moved_before: cap(body.moved_before) || "" } : {}),
+            ...(stagedAssets.length ? { staged_assets: stagedAssets } : {}),
+          };
           store.addEdit(key, label, kind, cap(body.before), cap(body.after), cap(body.before_html), cap(body.after_html), extra);
           return json(res, 200, { page: pageState(key) });
         }
 
-        // A pasted image: write it next to the reviewed file so the relative
-        // src resolves in the review, in the saved file, and for the agent.
+        // File reviews keep pasted images beside the document. Localhost
+        // reviews stage them privately until the agent moves them into source.
         if (action === "asset" && req.method === "POST") {
           const page = store.page(key);
-          if (page.kind === "url") {
-            return json(res, 400, { error: "Pasting images works on file reviews — for localhost pages, add the image to the app source." });
-          }
           const type = String(url.searchParams.get("type") || "");
           const ext = { "image/png": "png", "image/jpeg": "jpg", "image/gif": "gif", "image/webp": "webp" }[type];
           if (!ext) return json(res, 400, { error: `unsupported image type: ${type || "unknown"}` });
           const bytes = await readRawBody(req);
           if (!bytes.length) return json(res, 400, { error: "empty image" });
-          const dir = path.join(path.dirname(page.file), "assets");
+          const staged = page.kind === "url";
+          const dir = staged ? path.join(stateDir(), "pasted", key) : path.join(path.dirname(page.file), "assets");
           fs.mkdirSync(dir, { recursive: true });
-          const base = path
-            .basename(page.file)
-            .replace(/\.[^.]+$/, "")
-            .replace(/[^\w-]+/g, "-");
+          const base = staged
+            ? "localhost"
+            : path
+                .basename(page.file)
+                .replace(/\.[^.]+$/, "")
+                .replace(/[^\w-]+/g, "-");
           let name = "";
           for (let n = 1; ; n += 1) {
             name = `${base}-paste-${n}.${ext}`;
             if (!fs.existsSync(path.join(dir, name))) break;
           }
-          fs.writeFileSync(path.join(dir, name), bytes);
-          return json(res, 200, { src: `assets/${name}` });
+          const saved = path.join(dir, name);
+          fs.writeFileSync(saved, bytes);
+          return json(res, 200, {
+            src: staged ? `/artifact/${key}/__human_review_paste__/${name}` : `assets/${name}`,
+            ...(staged ? { stagedId: name } : {}),
+          });
         }
 
         if (action === "save" && req.method === "POST") {

--- a/src/state.js
+++ b/src/state.js
@@ -213,7 +213,13 @@ export class Store {
         if (after !== undefined) row.after = after;
         if (afterHtml !== undefined) row.after_html = afterHtml;
         // A re-move of the same block replaces its landing spot.
-        if (extra) Object.assign(row, extra);
+        if (extra) {
+          if (extra.staged_assets) {
+            const assets = [...(row.staged_assets || []), ...extra.staged_assets];
+            extra = { ...extra, staged_assets: [...new Map(assets.map((asset) => [asset.path, asset])).values()] };
+          }
+          Object.assign(row, extra);
+        }
         row.updatedAt = Date.now();
         return;
       }

--- a/test/asset-paste.test.js
+++ b/test/asset-paste.test.js
@@ -111,3 +111,81 @@ test("pasted images land in assets/ next to the reviewed file", async (t) => {
     assert.equal(row.moved_before, "Closing paragraph");
   });
 });
+
+test("localhost image pastes are staged, previewed, and delivered to the agent", async (t) => {
+  const app = http.createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    res.end('<!doctype html><html><body><p data-block="Intro">Hello</p></body></html>');
+  });
+  await new Promise((resolve, reject) => {
+    app.once("error", reject);
+    app.listen(0, "127.0.0.1", resolve);
+  });
+  t.after(() => app.close());
+
+  const review = await start();
+  t.after(() => review.dispose());
+  const target = `http://localhost:${app.address().port}/wiki`;
+  const opened = JSON.parse(
+    (
+      await request(review.port, {
+        method: "POST",
+        route: "/api/session",
+        headers: { "x-human-review-token": review.token, "content-type": "application/json" },
+        body: JSON.stringify({ target }),
+      })
+    ).raw
+  );
+
+  const pasted = await request(review.port, {
+    method: "POST",
+    route: `/api/page/${opened.key}/asset?type=${encodeURIComponent("image/png")}`,
+    headers: { "x-human-review-token": review.token, "content-type": "application/octet-stream" },
+    body: PNG,
+  });
+  assert.equal(pasted.status, 200, pasted.raw);
+  const asset = JSON.parse(pasted.raw);
+  assert.equal(asset.src, `/artifact/${opened.key}/__human_review_paste__/localhost-paste-1.png`);
+  assert.equal(asset.stagedId, "localhost-paste-1.png");
+  const stagedPath = path.join(process.env.HUMAN_REVIEW_STATE_DIR, "pasted", opened.key, asset.stagedId);
+  assert.deepEqual(fs.readFileSync(stagedPath), PNG);
+
+  const preview = await request(review.port, { route: asset.src });
+  assert.equal(preview.status, 200);
+
+  const afterHtml = `<p data-block="Intro">Hello<img src="${asset.src}"></p>`;
+  await request(review.port, {
+    method: "POST",
+    route: `/api/page/${opened.key}/edit`,
+    headers: { "x-human-review-token": review.token, "content-type": "application/json" },
+    body: JSON.stringify({
+      label: "Intro",
+      kind: "edited",
+      before: "Hello",
+      after: "Hello",
+      after_html: afterHtml,
+      staged_assets: [{ id: asset.stagedId, preview_src: asset.src }],
+    }),
+  });
+  await request(review.port, {
+    method: "POST",
+    route: `/api/page/${opened.key}/send`,
+    headers: { "x-human-review-token": review.token, "content-type": "application/json" },
+    body: JSON.stringify({ sessionId: opened.sessionId, note: "" }),
+  });
+
+  const polled = await request(review.port, {
+    route: `/api/poll?target=${encodeURIComponent(target)}`,
+    headers: { "x-human-review-token": review.token },
+  });
+  const edit = JSON.parse(polled.raw).pages[0].edits[0];
+  assert.equal(edit.after_html, afterHtml);
+  assert.deepEqual(edit.staged_assets, [{ path: stagedPath, preview_src: asset.src }]);
+
+  const acknowledged = await fetch(
+    `http://127.0.0.1:${review.port}/api/poll?target=${encodeURIComponent(target)}&ack=1`,
+    { headers: { "x-human-review-token": review.token } }
+  );
+  await acknowledged.body.cancel();
+  assert.equal(fs.existsSync(stagedPath), false, "the staged copy is removed after the agent acknowledges the batch");
+});


### PR DESCRIPTION
## What changed

- Fade drag and delete controls until hover
- Hide those controls while typing or selecting text
- Stage pasted PNG, JPEG, GIF, and WebP images during localhost reviews
- Preview staged images at the insertion point and include their local paths in the agent batch
- Remove staged copies after the agent acknowledges the batch
- Bump the package to 0.6.1

## Why

Localhost reviews previously rejected pasted images because Human Review could not safely guess a framework's source asset location. Staging lets the user edit visually while leaving final source placement to the agent.

## Validation

- `npm test`: 91 tests passed
- `npm pack --dry-run --cache /private/tmp/human-review-npm-cache`
- `git diff --check`
- Node syntax checks for the modified runtime files
