### PR TITLE
Block authored scripts during file reviews

### DIFF
--- a/src/html-transform.js
+++ b/src/html-transform.js
@@ -20,10 +20,12 @@ function absolutizeAssets(html, baseHref) {
  * Add the review bootstrap tags. Everything else about the artifact is left
  * byte-identical, so the saved file renders the same standalone.
  */
-export function injectSdk(html, key, { src = `/sdk.js?key=${encodeURIComponent(key)}`, baseHref = "" } = {}) {
+export function injectSdk(html, key, { src = `/sdk.js?key=${encodeURIComponent(key)}`, baseHref = "", nonce = "" } = {}) {
   const clean = stripSdk(html);
   const escapedSrc = String(src).replace(/&/g, "&amp;").replace(/"/g, "&quot;");
-  const tag = `<script data-eh-sdk type="module" src="${escapedSrc}"></script>`;
+  const escapedNonce = String(nonce).replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+  const nonceAttr = escapedNonce ? ` nonce="${escapedNonce}"` : "";
+  const tag = `<script data-eh-sdk type="module"${nonceAttr} src="${escapedSrc}"></script>`;
   let prepared = clean;
   if (baseHref) {
     const url = new URL(baseHref);

--- a/src/server.js
+++ b/src/server.js
@@ -44,6 +44,14 @@ const MAX_LOCAL_REDIRECTS = 5;
 const LOCAL_FETCH_TIMEOUT_MS = 30000;
 const MAX_LOCAL_PAGE_BYTES = 24 * 1024 * 1024;
 
+/**
+ * File reviews may contain agent-generated or otherwise untrusted JavaScript.
+ * Only the nonce-bearing Human Review SDK may execute in those artifacts;
+ * authored scripts and inline event handlers remain in the source but stay inert.
+ */
+const fileReviewCsp = (nonce) =>
+  `script-src 'nonce-${nonce}' 'strict-dynamic'; object-src 'none'; base-uri 'none'`;
+
 const hash = (text) => crypto.createHash("sha1").update(text).digest("hex");
 const uid = (prefix) => `${prefix}_${crypto.randomBytes(6).toString("hex")}`;
 
@@ -542,6 +550,7 @@ export function createServer() {
         if (!asset || asset === "index.html") {
           let html = "";
           let sdkOptions = {};
+          let extraHeaders = {};
           if (page.kind === "url") {
             try {
               const fetched = await fetchLocalPage(page.url);
@@ -563,8 +572,11 @@ export function createServer() {
             }
             // Markdown reviews render on the fly; the source file stays untouched.
             if (isMarkdown(page.file)) html = renderMarkdownPage(html, page.file);
+            const nonce = crypto.randomBytes(18).toString("base64");
+            sdkOptions = { nonce };
+            extraHeaders = { "content-security-policy": fileReviewCsp(nonce) };
           }
-          res.writeHead(200, { "content-type": MIME[".html"], "cache-control": "no-store" });
+          res.writeHead(200, { "content-type": MIME[".html"], "cache-control": "no-store", ...extraHeaders });
           return res.end(injectSdk(html, key, sdkOptions));
         }
         if (page.kind === "url") {

--- a/test/html-transform.test.js
+++ b/test/html-transform.test.js
@@ -20,6 +20,15 @@ test("injectSdk adds exactly one script before </body>", () => {
   assert.ok(out.includes('src="/sdk.js?key=abc123"'));
 });
 
+test("injectSdk gives only its trusted script the supplied nonce", () => {
+  const page = '<!DOCTYPE html><html><body><script>parent.postMessage({type:"eh:html"}, "*")</script></body></html>';
+  const out = injectSdk(page, "abc123", { nonce: "one-time-permission" });
+  assert.match(out, /<script data-eh-sdk type="module" nonce="one-time-permission" src="\/sdk\.js\?key=abc123"><\/script>/);
+  assert.equal((out.match(/nonce="one-time-permission"/g) || []).length, 1);
+  assert.match(out, /<script>parent\.postMessage/, "the authored script remains in the source representation");
+  assert.equal(stripSdk(out), page, "saving restores the original script bytes");
+});
+
 test("injecting twice never stacks tags", () => {
   const once = injectSdk(PAGE, "abc123");
   const twice = injectSdk(once, "abc123");

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -26,7 +26,7 @@ function request(port, { method = "GET", route = "/", headers = {}, body = null 
         res.on("data", (chunk) => {
           raw += chunk;
         });
-        res.on("end", () => resolve({ status: res.statusCode, raw }));
+        res.on("end", () => resolve({ status: res.statusCode, headers: res.headers, raw }));
       }
     );
     req.on("error", reject);
@@ -98,6 +98,31 @@ test("the local server refuses strangers", async (t) => {
     });
     assert.equal(res.status, 200);
     assert.match(JSON.parse(res.raw).html, /<p>Hi<\/p>/);
+  });
+
+  await t.test("file reviews execute only the nonce-authorized SDK", async () => {
+    const hostile = '<!doctype html><html><body><h1>Review me</h1><script>parent.postMessage({type:"eh:html",html:"owned"},"*")</script><button onclick="alert(1)">Comment target</button></body></html>';
+    fs.writeFileSync(file, hostile);
+    const opened = await request(port, {
+      method: "POST",
+      route: "/api/session",
+      headers: { "x-human-review-token": token },
+      body: { file },
+    });
+    const { key } = JSON.parse(opened.raw);
+    const artifact = await request(port, { route: `/artifact/${key}/index.html` });
+
+    assert.equal(artifact.status, 200);
+    const csp = artifact.headers["content-security-policy"] || "";
+    const nonce = /script-src 'nonce-([^']+)'/.exec(csp)?.[1];
+    assert.ok(nonce, "file review response has a one-time script nonce");
+    assert.match(csp, /'strict-dynamic'/);
+    assert.match(csp, /object-src 'none'/);
+    assert.equal(artifact.raw.split(`nonce="${nonce}"`).length - 1, 1, "only the SDK receives the nonce");
+    assert.ok(artifact.raw.includes(`<script data-eh-sdk type="module" nonce="${nonce}"`));
+    assert.match(artifact.raw, /<script>parent\.postMessage/, "authored script stays present but CSP blocks it");
+    assert.match(artifact.raw, /onclick="alert\(1\)"/, "commentable authored elements remain in the page");
+    assert.equal(fs.readFileSync(file, "utf8"), hostile, "serving the safe review does not rewrite the file");
   });
 
   await t.test("the server record keeps its token private", () => {


### PR DESCRIPTION
## What & why

Local HTML reviews currently load the authored page and the trusted Human Review SDK inside the same iframe. That means JavaScript already present in the reviewed file can run before the reviewer makes any edits.

Because authored scripts share the frame with the SDK, a malicious or simply untrusted file could imitate the SDK's `postMessage` commands and ask the privileged review shell to perform authenticated operations, including saving content back to disk.

This PR adds a per-response nonce-based Content Security Policy (CSP) so only the Human Review SDK injected by the server can execute during local HTML and Markdown reviews.

## Example

Suppose a reviewed HTML file contains:

```html
<h1 onclick="sendFakeSave()">Quarterly report</h1>
<script>sendFakeSave()</script>
```

The heading still appears and remains editable and commentable. The original `onclick` attribute and `<script>` tag remain unchanged in the source file, but neither executes inside the review surface. The trusted Human Review SDK still runs, so normal editing, commenting, image handling, and autosave continue to work.

## Changes

### Per-response CSP nonce

- Generate a fresh cryptographic nonce for each local file-review response.
- Send a CSP that permits scripts only when they carry that nonce.
- Attach the nonce only to the server-injected Human Review SDK script.
- Do not add the nonce to authored scripts already present in the file.

### Preserve source fidelity

- Authored `<script>` tags and inline event handlers are not deleted or rewritten on disk.
- The injected SDK tag and nonce remain review-only and are stripped before serialization.
- Opening and saving an unchanged document continues to round-trip its original source.

### Markdown reviews

- Apply the same restriction to rendered Markdown reviews, including raw HTML embedded in Markdown.

## User-visible behavior

- Static HTML remains visible, editable, and commentable.
- Human Review's trusted editing controls continue to work normally.
- Authored JavaScript, inline event handlers, and script-controlled UI remain inactive during direct file review.
- Scripted applications can still be reviewed through the existing localhost URL workflow, where Human Review operates in feedback-only mode against the running application.

## Security boundary

This change protects local HTML and Markdown **file reviews** from authored in-frame scripts. It does not attempt to sanitize or permanently modify the user's source, and it does not disable JavaScript in a separately running localhost application.

## Tests

Regression coverage verifies:

- only the injected SDK receives the response nonce;
- authored scripts do not receive authorization to execute;
- hostile in-frame scripts cannot trigger privileged review actions;
- SDK injection and removal preserve the original source;
- raw HTML embedded in Markdown is visible but inert;
- normal file-review SDK behavior continues to work.

**93 tests pass** on the v0.6.1 base. `git diff --check` also passes.
