### PR TITLE
Use document filename as browser tab title

### DIFF
--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -138,6 +138,7 @@ const clock = () => new Date().toLocaleTimeString([], { hour: "numeric", minute:
 function render() {
   const page = state.page;
   if (!page) return;
+  document.title = page.filename || 'human-review';
 
   const comments = page.comments || [];
   const edits = page.edits || [];


### PR DESCRIPTION
When reviewing multiple documents, all browser tabs showed
"human review" — you couldn't tell which tab had which document.

This sets document.title to the filename already computed by
pageState() (e.g. index.html, README.md, or the URL pathname),
falling back to 'human-review' when no page is loaded.

Change: 1 line in src/chrome-client.js render().

Closes #24