### PR TITLE
Harden review frame: drop popup/download rights, validate external hrefs

### DIFF
--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -6,6 +6,7 @@
  */
 import { tidy } from "./anchor-text.js";
 import { pageUrl, replacePage } from "./chrome-session.js";
+import { normalizeHref } from "./editing.js";
 import { framePolicy } from "./frame-policy.js";
 
 const $ = (id) => document.getElementById(id);
@@ -607,9 +608,14 @@ window.addEventListener("message", async (event) => {
     case "eh:scroll":
       state.scroll = { x: msg.x, y: msg.y };
       break;
-    case "eh:external":
-      window.open(msg.href, "_blank", "noopener");
+    case "eh:external": {
+      // This side is what actually calls window.open, so it re-checks the
+      // scheme rather than trusting the frame: a javascript: or data: URL
+      // arriving here would run on this origin, next to the token.
+      const external = normalizeHref(msg.href);
+      if (external) window.open(external, "_blank", "noopener");
       break;
+    }
     case "eh:navigate":
       try {
         const result = await api(`/api/session/${state.sessionId}/navigate`, {

--- a/src/chrome.html
+++ b/src/chrome.html
@@ -12,7 +12,7 @@
       <iframe
         id="frame"
         title="Artifact under review"
-        sandbox="allow-scripts allow-forms allow-modals allow-popups allow-downloads"></iframe>
+        sandbox="allow-scripts allow-forms allow-modals"></iframe>
     </main>
 
     <button type="button" id="handle" class="handle" title="Hide comments panel" aria-label="Hide comments panel">›</button>

--- a/src/frame-policy.js
+++ b/src/frame-policy.js
@@ -1,4 +1,4 @@
-const BASE_SANDBOX = "allow-scripts allow-forms allow-modals allow-popups allow-downloads";
+const BASE_SANDBOX = "allow-scripts allow-forms allow-modals";
 
 /**
  * Localhost apps need their real origin so their routing and JavaScript work.

--- a/test/frame-policy.test.js
+++ b/test/frame-policy.test.js
@@ -19,3 +19,14 @@ test("file and Markdown reviews use an opaque origin", () => {
     assert.equal(policy.targetOrigin, "*");
   }
 });
+
+test("no review grants the frame popups or downloads", () => {
+  // The SDK hands external links to the chrome over postMessage, which opens
+  // them itself, so the frame never needs allow-popups. Nothing needs
+  // allow-downloads. Untrusted artifacts get neither.
+  for (const page of [{ kind: "url" }, { kind: "file", markdown: false }, { kind: "file", markdown: true }]) {
+    const policy = framePolicy(page, artifactOrigin);
+    assert.doesNotMatch(policy.sandbox, /\ballow-popups\b/);
+    assert.doesNotMatch(policy.sandbox, /\ballow-downloads\b/);
+  }
+});


### PR DESCRIPTION
Two small hardening changes to the review chrome. Both turned up while I was reading through the frame policy before installing the skill, and both looked worth sending back rather than just patching locally.

### Frame sandbox drops `allow-popups` and `allow-downloads`

The iframe renders artifacts that are untrusted by definition, and its sandbox granted popups and downloads. Neither appears to be needed.

`allow-popups` in particular is redundant with the design that is already there: `sdk.js` does not open external links itself, it posts `eh:external` to the chrome, and the chrome calls `window.open`. The frame already delegates popup-opening upward, so granting it the capability directly just widens what a hostile artifact can do to the reviewer. Nothing in the tree references downloads at all.

Remaining sandbox is `allow-scripts allow-forms allow-modals`, plus `allow-same-origin` for localhost reviews exactly as before.

### `eh:external` validates the href before `window.open`

The handler passed `msg.href` straight through. The origin check is the only thing in front of it, so a compromised frame or a misconfigured policy could land a `javascript:` URL there, and it would execute on the chrome's origin next to the session token.

Rather than add a second URL-safety helper, this routes the href through the existing `normalizeHref` in `editing.js`. It already allowlists http/https/mailto/tel and already has coverage for `javascript:`, `data:`, `vbscript:`, and tab-obfuscated variants like `java\tscript:`. Reusing it keeps one place where scheme policy lives.

### Tests

92/92 pass. Added one regression test asserting no review grants the frame popups or downloads, and confirmed it fails against the previous constant before keeping it, so a revert cannot pass silently.

### Not changed

`framePolicy` still returns `targetOrigin: "*"` for file and Markdown reviews. Tightening that to `"null"` for the opaque-origin case might be worth considering, but it changes an existing asserted value and felt like your call rather than mine.

Happy to adjust or split this if you would prefer it in separate PRs.
