### PR TITLE
Retry the atomic rename when Windows briefly locks the temp file

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -9,19 +9,95 @@ const PRUNE_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const fresh = (entry, now) => !!entry && now - (entry.updatedAt || 0) < PRUNE_AGE_MS;
 
 /**
+ * Windows lets a virus scanner or indexer hold a brief handle on a file the
+ * moment it is created, and a rename against that handle fails with EPERM,
+ * EACCES or EBUSY. The handle is gone within a few milliseconds, so the write
+ * is not really lost -- it just has to be asked for again. Measured on a box
+ * running McAfee real-time protection, ~4% of renames failed on the first try
+ * and none survived a short backoff.
+ */
+const RETRYABLE_RENAME = new Set(["EPERM", "EACCES", "EBUSY"]);
+const RENAME_TRIES = 5;
+
+/** Sleep without going async: atomicWrite is synchronous by contract. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Drop the temp file after a failed write. The handle that blocked the rename
+ * blocks the unlink for exactly as long, so a single attempt would strand the
+ * file in the state directory -- and nothing else ever sweeps it. Give up
+ * quietly once the retries are spent: the caller is already throwing the error
+ * that matters, and a leftover temp file must not mask it.
+ */
+function discardTmp(tmp, unlink, sleep) {
+  try {
+    for (let attempt = 0; attempt < RENAME_TRIES; attempt++) {
+      try {
+        unlink(tmp);
+        return;
+      } catch (err) {
+        if (err.code === "ENOENT" || !RETRYABLE_RENAME.has(err.code)) return;
+        // Nothing waits on the last attempt: no attempt follows it.
+        if (attempt === RENAME_TRIES - 1) return;
+        sleep(2 ** attempt);
+      }
+    }
+  } catch {
+    // Best effort by definition. Whatever failed in here -- including the
+    // sleep -- must never escape and replace the write error the caller is
+    // already throwing.
+  }
+}
+
+/**
  * Atomic write via a unique sibling tmp file. The name is unguessable and the
  * create is exclusive, so a pre-planted symlink can never redirect the write,
  * and a failed rename never leaves a predictable orphan behind.
  */
 export function atomicWrite(file, data) {
+  return writeThroughTmp(file, data, REAL);
+}
+
+/**
+ * The real calls, looked up at call time rather than captured here, so a test
+ * can drive the exported atomicWrite through its retry by patching fs.
+ */
+const REAL = {
+  rename: (from, to) => fs.renameSync(from, to),
+  unlink: (target) => fs.unlinkSync(target),
+  sleep: (ms) => sleepSync(ms),
+};
+
+/**
+ * atomicWrite's body. Private: nothing outside this module may hand it a
+ * rename that quietly does nothing and reports a successful write. Tests
+ * reach the retry by patching fs, which REAL looks up at call time.
+ */
+function writeThroughTmp(file, data, overrides) {
+  // Merged per key, so a test can replace one call and still exercise the
+  // real implementations of the others.
+  const { rename, unlink, sleep } = { ...REAL, ...overrides };
   const tmp = `${file}.${process.pid}.${crypto.randomBytes(6).toString("hex")}.human-review.tmp`;
   fs.writeFileSync(tmp, data, { flag: "wx" });
   try {
-    fs.renameSync(tmp, file);
+    for (let attempt = 0; ; attempt++) {
+      try {
+        rename(tmp, file);
+        return;
+      } catch (err) {
+        if (attempt >= RENAME_TRIES - 1 || !RETRYABLE_RENAME.has(err.code)) throw err;
+        try {
+          sleep(2 ** attempt);
+        } catch {
+          // A broken sleeper is not the failure worth reporting.
+          throw err;
+        }
+      }
+    }
   } catch (err) {
-    try {
-      fs.unlinkSync(tmp);
-    } catch {}
+    discardTmp(tmp, unlink, sleep);
     throw err;
   }
 }

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -7,7 +7,7 @@ import path from "node:path";
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-test-"));
 process.env.HUMAN_REVIEW_STATE_DIR = path.join(tmp, "state");
 
-const { Store, resolveAsset } = await import("../src/state.js");
+const { Store, atomicWrite, resolveAsset } = await import("../src/state.js");
 const { canonicalTarget, localUrl, targetKey } = await import("../src/paths.js");
 
 function page(name, body) {
@@ -159,5 +159,238 @@ test(
     assert.equal(resolveAsset(file, "style.css"), fs.realpathSync(path.join(dir, "style.css")));
   }
 );
+
+/**
+ * atomicWrite's retry lives behind the fs calls it makes, not behind an
+ * exported seam, so these tests swap those calls out and drive the real
+ * two-argument entry point. Atomics.wait stands in for the backoff: sleepSync
+ * is the only thing that calls it.
+ */
+const realRename = fs.renameSync;
+const realUnlink = fs.unlinkSync;
+const realWait = Atomics.wait;
+
+function withPatchedFs({ rename, unlink, wait }, fn) {
+  if (rename) fs.renameSync = rename;
+  if (unlink) fs.unlinkSync = unlink;
+  if (wait) Atomics.wait = wait;
+  try {
+    return fn();
+  } finally {
+    fs.renameSync = realRename;
+    fs.unlinkSync = realUnlink;
+    Atomics.wait = realWait;
+  }
+}
+
+const fail = (code) => {
+  const err = new Error(code + ": simulated");
+  err.code = code;
+  return err;
+};
+
+/** A rename that fails with `code` its first `times` calls, then succeeds. */
+function flakyRename(code, times) {
+  const calls = { count: 0 };
+  return {
+    calls,
+    rename: (from, to) => {
+      if (++calls.count <= times) throw fail(code);
+      return realRename(from, to);
+    },
+  };
+}
+
+/** Records the backoff without actually waiting, so the suite stays fast. */
+function recordWaits(slept) {
+  return (...args) => {
+    slept.push(args[3]);
+    return "timed-out";
+  };
+}
+
+const orphans = (dir) => fs.readdirSync(dir).filter((n) => n.endsWith(".human-review.tmp"));
+const scratch = (name) => fs.mkdtempSync(path.join(tmp, name));
+
+function capture(fn) {
+  try {
+    fn();
+  } catch (err) {
+    return err;
+  }
+  return undefined;
+}
+
+for (const code of ["EPERM", "EACCES", "EBUSY"]) {
+  test("atomicWrite retries a " + code + " rename, which Windows scanners cause", () => {
+    const dir = scratch("retry-");
+    const file = path.join(dir, "state.json");
+    const { calls, rename } = flakyRename(code, 2);
+    const slept = [];
+
+    withPatchedFs({ rename, wait: recordWaits(slept) }, () => atomicWrite(file, "payload"));
+
+    assert.equal(fs.readFileSync(file, "utf8"), "payload");
+    assert.equal(calls.count, 3, "two failures then a success");
+    assert.deepEqual(slept, [1, 2], "backs off between attempts");
+    assert.deepEqual(orphans(dir), [], "no tmp file left behind");
+  });
+}
+
+test("atomicWrite gives up after a bounded number of retries", () => {
+  const dir = scratch("give-up-");
+  const file = path.join(dir, "state.json");
+  const { calls, rename } = flakyRename("EPERM", Infinity);
+  const slept = [];
+
+  const thrown = withPatchedFs({ rename, wait: recordWaits(slept) }, () =>
+    capture(() => atomicWrite(file, "payload"))
+  );
+
+  assert.equal(thrown?.code, "EPERM", "a truly stuck file still surfaces its error");
+  assert.equal(calls.count, 5, "bounded");
+  assert.deepEqual(slept, [1, 2, 4, 8], "no wait after the final attempt");
+  assert.equal(fs.existsSync(file), false);
+  assert.deepEqual(orphans(dir), [], "cleans up even when every attempt fails");
+});
+
+test("atomicWrite never retries an error that a retry cannot fix", () => {
+  const dir = scratch("fatal-");
+  const file = path.join(dir, "state.json");
+  const { calls, rename } = flakyRename("ENOSPC", Infinity);
+  const slept = [];
+
+  const thrown = withPatchedFs({ rename, wait: recordWaits(slept) }, () =>
+    capture(() => atomicWrite(file, "payload"))
+  );
+
+  assert.equal(thrown?.code, "ENOSPC");
+  assert.equal(calls.count, 1, "fails fast");
+  assert.deepEqual(slept, []);
+  assert.deepEqual(orphans(dir), []);
+});
+
+test("atomicWrite clears the temp file even when the unlink is blocked too", () => {
+  const dir = scratch("unlink-blocked-");
+  const file = path.join(dir, "state.json");
+  const { rename } = flakyRename("EPERM", Infinity);
+  const slept = [];
+
+  // The handle that blocks the rename blocks the unlink for just as long.
+  let unlinkCalls = 0;
+  const unlink = (target) => {
+    if (++unlinkCalls <= 2) throw fail("EPERM");
+    return realUnlink(target);
+  };
+
+  const thrown = withPatchedFs({ rename, unlink, wait: recordWaits(slept) }, () =>
+    capture(() => atomicWrite(file, "payload"))
+  );
+
+  assert.equal(thrown?.code, "EPERM");
+  assert.equal(unlinkCalls, 3, "keeps trying while the handle is held");
+  assert.deepEqual(orphans(dir), [], "nothing stranded in the state directory");
+  // The first four waits are the rename retries; the rest is cleanup backing
+  // off, so dropping that sleep would fail here.
+  assert.deepEqual(slept, [1, 2, 4, 8, 1, 2], "cleanup backs off as well");
+});
+
+test("cleanup exhaustion is bounded the same way the rename retry is", () => {
+  const dir = scratch("unlink-stuck-");
+  const file = path.join(dir, "state.json");
+  const { rename } = flakyRename("EPERM", Infinity);
+  const slept = [];
+
+  const cleanupFailure = fail("EPERM");
+  let unlinkCalls = 0;
+  const unlink = () => {
+    unlinkCalls++;
+    throw cleanupFailure;
+  };
+
+  const thrown = withPatchedFs({ rename, unlink, wait: recordWaits(slept) }, () =>
+    capture(() => atomicWrite(file, "payload"))
+  );
+
+  // Both errors carry EPERM, so only identity can tell them apart.
+  assert.ok(thrown, "the write failure has to reach the caller");
+  assert.notEqual(thrown, cleanupFailure, "the write error survives, not the cleanup error");
+  assert.equal(unlinkCalls, 5, "cleanup gives up after the same number of attempts");
+  assert.deepEqual(slept, [1, 2, 4, 8, 1, 2, 4, 8], "no wait after the final attempt");
+});
+
+test("a sleep that throws mid-retry cannot hijack the rename error", () => {
+  const dir = scratch("retry-sleep-throws-");
+  const file = path.join(dir, "state.json");
+  const { rename } = flakyRename("EPERM", Infinity);
+  const sleepFailure = new Error("sleep exploded");
+
+  // The very first wait belongs to the retry loop, so this covers the retry
+  // phase; the cleanup phase is covered below.
+  const thrown = withPatchedFs(
+    {
+      rename,
+      wait: () => {
+        throw sleepFailure;
+      },
+    },
+    () => capture(() => atomicWrite(file, "payload"))
+  );
+
+  assert.ok(thrown, "the write failure has to reach the caller");
+  assert.notEqual(thrown, sleepFailure, "a broken sleeper must not become the reported error");
+  assert.equal(thrown.code, "EPERM");
+  assert.deepEqual(orphans(dir), []);
+});
+
+test("a sleep that throws during cleanup cannot hijack the write error either", () => {
+  const dir = scratch("cleanup-sleep-throws-");
+  const file = path.join(dir, "state.json");
+  const { rename } = flakyRename("EPERM", Infinity);
+  const sleepFailure = new Error("sleep exploded");
+
+  // Cleanup is the only phase that calls unlink, so that marks the boundary.
+  let inCleanup = false;
+  const unlink = () => {
+    inCleanup = true;
+    throw fail("EPERM");
+  };
+
+  const thrown = withPatchedFs(
+    {
+      rename,
+      unlink,
+      wait: () => {
+        if (inCleanup) throw sleepFailure;
+        return "timed-out";
+      },
+    },
+    () => capture(() => atomicWrite(file, "payload"))
+  );
+
+  assert.ok(inCleanup, "the test has to actually reach the cleanup path");
+  assert.ok(thrown, "the write failure has to reach the caller");
+  assert.notEqual(thrown, sleepFailure, "a broken sleeper must not become the reported error");
+  assert.equal(thrown.code, "EPERM");
+});
+
+test("the backoff really sleeps, on Node's main thread", () => {
+  const dir = scratch("real-sleep-");
+  const file = path.join(dir, "state.json");
+  const { calls, rename } = flakyRename("EPERM", 3);
+
+  // Atomics.wait is left alone here, so this runs the real sleeper. Spying on
+  // it would prove it was called but not that it waited; elapsed time is the
+  // part a no-op cannot fake.
+  const started = process.hrtime.bigint();
+  withPatchedFs({ rename }, () => atomicWrite(file, "payload"));
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+
+  assert.equal(fs.readFileSync(file, "utf8"), "payload");
+  assert.equal(calls.count, 4);
+  // Waits total 1 + 2 + 4 = 7ms; allow a little timer granularity, but stay
+  // far above the ~0ms a no-op or throwing sleeper would take.
+  assert.ok(elapsedMs >= 6, "expected a real delay, waited " + elapsedMs.toFixed(2) + "ms");
+});
 
 test.after(() => fs.rmSync(tmp, { recursive: true, force: true }));


### PR DESCRIPTION
## The problem

On Windows, a virus scanner or indexer can hold a short-lived handle on a file the moment it is created. A rename against that handle fails with `EPERM`, `EACCES` or `EBUSY`.

`atomicWrite` is unusually exposed to this: it creates a temp file and immediately renames it over `state.json`. That is the narrowest possible window for a scanner to still be holding the file it just saw appear.

This is not a concurrency problem. It happens with a single process writing sequentially. On my machine (Windows 11, Node 24, McAfee real-time protection):

```
500 sequential atomicWrite calls, system temp dir : 19 failed, EPERM on rename
500 sequential atomicWrite calls, ~/.human-review : 23 failed, EPERM on rename
```

Roughly **one in twenty-five writes**, and each one is a batch of comments or edits the user had already typed into the browser.

I first noticed it because `npm test` was failing differently on each run — the failures moved between `state.test.js`, `concurrent.test.js` and others, which is what sent me looking at `atomicWrite` rather than at any one test.

## The fix

The handle clears within a few milliseconds, so the write is not really lost — it just has to be asked for again. The rename retries with a short exponential backoff. Same measurement after the change:

```
500 sequential atomicWrite calls : 0 failed, 14 needed a retry, worst case 2 retries (~3ms)
```

Two things beyond the obvious retry:

**Cleanup needs it too.** The handle that blocks the rename blocks the `unlink` for exactly as long, so the single cleanup attempt could strand a `.human-review.tmp` file containing the newest state. Nothing ever sweeps that directory — `prune()` only ages out entries inside the JSON — so it would sit there indefinitely. Cleanup now retries on the same schedule, then gives up quietly: a stuck temp file must never mask the error the caller is already throwing.

**Neither sleep can escape.** For the same reason, an exception from the backoff would otherwise surface in place of the real write error.

## What is deliberately unchanged

- **The exported signature.** `atomicWrite(file, data)` is exactly as it was. The injection the tests use is private, so no caller can hand it a rename that quietly does nothing and reports a successful write. Exports remain `atomicWrite`, `Store`, `resolveAsset`.
- **Non-retryable errors still fail on the first attempt.** `ENOSPC` and friends do not sleep and do not retry.
- **The retry is bounded**, so a genuinely stuck file still surfaces its error rather than hanging.
- **The security properties**: exclusive `wx` create, unguessable temp name, symlink resistance.

## Tests

Ten new tests in `test/state.test.js`. They reach the retry by patching the calls `atomicWrite` makes — `fs.renameSync`, `fs.unlinkSync`, and `Atomics.wait` (which only `sleepSync` uses) — so every one of them drives the real two-argument `atomicWrite` rather than a test-only seam.

I checked they actually fail without each fix, by reverting one piece at a time:

| Reverted | Result |
|---|---|
| One-shot rename (no retry) | 7 tests fail |
| `RENAME_TRIES` 5 → 6 | 3 tests fail |
| `EBUSY` dropped from the retryable set | 1 test fails |
| Single-attempt cleanup | 2 tests fail |
| Cleanup's final-attempt guard | 1 test fails |
| Cleanup sleep containment | 1 test fails |
| Retry sleep containment | 1 test fails |
| `sleepSync` → no-op | 7 tests fail |

`node --test` → **101 tests, 100 pass, 1 skipped** (the existing symlink test, which needs Windows privileges).

## One note on running the suite

`npm test` reports 3 files as failing on Windows:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
```

Every assertion inside those files passes — it is `--test-force-exit` crashing libuv during teardown for the files that open a server (`asset-paste`, `command-cache`, `url-review`). Plain `node --test` exits cleanly. Unrelated to this change and not something I touched, but it may be worth knowing if Windows CI ever gets set up.
