### PR TITLE
Sweep orphaned staged pastes on server start

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -94,8 +94,55 @@ async function fetchLocalPage(target, redirects = 0) {
   return { html: await readCapped(response, url), resolvedUrl: response.url || url };
 }
 
+/**
+ * Staged localhost pastes are deleted when their batch is acked. A batch that
+ * never gets acked (the agent died, the page was pruned) would leave them
+ * behind forever, so on start drop every staged file that no live edit or
+ * pending batch still refers to.
+ */
+function sweepStagedPastes(store) {
+  const root = path.join(stateDir(), "pasted");
+  let keys;
+  try {
+    keys = fs.readdirSync(root);
+  } catch {
+    return;
+  }
+  const live = new Set();
+  for (const page of Object.values(store.data.pages)) {
+    for (const edit of page.edits || []) {
+      for (const asset of edit.staged_assets || []) live.add(path.resolve(asset.path));
+    }
+  }
+  for (const record of Object.values(store.allBatches())) {
+    for (const entry of record.cleanup || []) {
+      for (const file of entry.staged || []) live.add(path.resolve(file));
+    }
+  }
+  for (const key of keys) {
+    const dir = path.join(root, key);
+    let files;
+    try {
+      files = fs.readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      const full = path.join(dir, file);
+      if (live.has(path.resolve(full))) continue;
+      try {
+        fs.unlinkSync(full);
+      } catch {}
+    }
+    try {
+      fs.rmdirSync(dir);
+    } catch {}
+  }
+}
+
 export function createServer() {
   const store = new Store();
+  sweepStagedPastes(store);
   const cliInvocation = invocation();
 
   /**

--- a/test/asset-paste.test.js
+++ b/test/asset-paste.test.js
@@ -189,3 +189,68 @@ test("localhost image pastes are staged, previewed, and delivered to the agent",
   await acknowledged.body.cancel();
   assert.equal(fs.existsSync(stagedPath), false, "the staged copy is removed after the agent acknowledges the batch");
 });
+
+test("server start sweeps staged pastes that no edit or batch still references", async (t) => {
+  const app = http.createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    res.end('<!doctype html><html><body><p data-block="Intro">Hello</p></body></html>');
+  });
+  await new Promise((resolve, reject) => {
+    app.once("error", reject);
+    app.listen(0, "127.0.0.1", resolve);
+  });
+  t.after(() => app.close());
+
+  // Paste once so a staged file is referenced by a live edit, then plant
+  // orphans beside it and under a key no page owns any more.
+  const first = await start();
+  const target = `http://localhost:${app.address().port}/wiki`;
+  const opened = JSON.parse(
+    (
+      await request(first.port, {
+        method: "POST",
+        route: "/api/session",
+        headers: { "x-human-review-token": first.token, "content-type": "application/json" },
+        body: JSON.stringify({ target }),
+      })
+    ).raw
+  );
+  const asset = JSON.parse(
+    (
+      await request(first.port, {
+        method: "POST",
+        route: `/api/page/${opened.key}/asset?type=${encodeURIComponent("image/png")}`,
+        headers: { "x-human-review-token": first.token, "content-type": "application/octet-stream" },
+        body: PNG,
+      })
+    ).raw
+  );
+  await request(first.port, {
+    method: "POST",
+    route: `/api/page/${opened.key}/edit`,
+    headers: { "x-human-review-token": first.token, "content-type": "application/json" },
+    body: JSON.stringify({
+      label: "Intro",
+      kind: "edited",
+      before: "Hello",
+      after: "Hello",
+      after_html: `<p data-block="Intro">Hello<img src="${asset.src}"></p>`,
+      staged_assets: [{ id: asset.stagedId, preview_src: asset.src }],
+    }),
+  });
+  await first.dispose();
+
+  const stagedRoot = path.join(process.env.HUMAN_REVIEW_STATE_DIR, "pasted");
+  const kept = path.join(stagedRoot, opened.key, asset.stagedId);
+  const orphanBeside = path.join(stagedRoot, opened.key, "localhost-paste-9.png");
+  const orphanDir = path.join(stagedRoot, "no-such-page");
+  fs.writeFileSync(orphanBeside, PNG);
+  fs.mkdirSync(orphanDir, { recursive: true });
+  fs.writeFileSync(path.join(orphanDir, "localhost-paste-1.png"), PNG);
+
+  const second = await start();
+  t.after(() => second.dispose());
+  assert.equal(fs.existsSync(kept), true, "a staged file referenced by a live edit survives");
+  assert.equal(fs.existsSync(orphanBeside), false, "an unreferenced file next to it is removed");
+  assert.equal(fs.existsSync(orphanDir), false, "a staging folder for a forgotten page is removed");
+});


### PR DESCRIPTION
## Summary
Staged localhost pastes (shipped in #31) are deleted when their batch is acked. A batch that never gets acked, because the agent died or the page was pruned, left those files in `~/.human-review/pasted/` forever.

On server start, drop every staged file that no live edit's `staged_assets` and no pending batch's cleanup list still refers to, and remove emptied per-page folders.

## Test plan
- [x] `npm test` — 92 passing, including a new test that pastes, restarts the server, and confirms the referenced file survives while an orphan beside it and a folder for a forgotten page are removed