### PR TITLE
Bulletproof the background wait, batch delivery, and the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Review a page running on localhost:
 
 Human Review opens the file in your browser. Make direct edits, leave comments, and click Send. Your agent receives all your feedback in one batch, updates the source, and refreshes the page for another review.
 
+The agent waits with a single background command that exits the moment you hit Send — no polling on a timer. Closing the tab, or clicking End review, releases the agent too. Feedback you never sent is kept, and the next time you open that page you can restore or discard it.
+
 Note: For HTML files, direct edits and resizes save automatically. For Markdown and localhost pages, click Send so your agent can apply them to the source.
 
 ## What this skill lets you do
@@ -60,7 +62,8 @@ Note: For HTML files, direct edits and resizes save automatically. For Markdown 
 - **Paste images** from your clipboard — file reviews save them beside the document; localhost reviews stage them for the agent to place in the app source.
 - **Select a phrase and leave a comment** anchored to the exact text.
 - **Comment on an image, chart, or section** by clicking the element.
-- **Remove elements** without explaining the deletion in chat.
+- **Remove elements** without explaining the deletion in chat. Deletes and moves come with an Undo.
+- **Edit a comment** after writing it, even one already sent — a reworded comment reaches the agent with the next Send.
 - **Command-click links** to review multiple pages without losing your feedback.
 - **Send every edit and comment at once** instead of writing a long chat message.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "human-review",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "human-review",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "marked": "^18.0.7"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "test": "node --test --test-force-exit",
+    "test": "node --test --test-force-exit --test-timeout=60000",
     "start": "node src/cli.js"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "human-review",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Review and edit agent-generated files and localhost pages in the browser, then send the whole batch back to your agent.",
   "author": "Peter Yang",
   "homepage": "https://github.com/petergyang/human-review#readme",

--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -43,13 +43,23 @@ keeping its formatting syntax.
 
    - **Claude Code:** run it with `run_in_background: true` and end your turn.
      Claude Code wakes you with the output the moment the command exits.
-   - **Codex, Cursor, and everything else:** run it in the **foreground** and
-     stay on it until it exits. Do not detach it or start it as a background
-     session — nothing will wake you when a detached command finishes, and
-     the user's Send will sit unread until they nudge you. If your shell tool
-     enforces a maximum command duration, pass `--timeout` a little under
-     that limit and run the same command again when it prints
-     `{"status":"timeout"}`.
+   - **Codex, Cursor, and everything else:** run it in the **foreground**,
+     inside your active turn, and stay on it until it prints `feedback` or
+     `closed`. Do not detach it or start it as a background session: nothing
+     wakes you when a detached command finishes. While the review is active:
+     - If the user sends a message, answer it as commentary and immediately
+       resume the foreground poll in the same turn. Do not send a final
+       response until the poll returns `feedback` or `closed` — a final
+       response ends the turn and kills the wait.
+     - If your shell tool caps command duration, pass `--timeout` a little
+       under the cap and run bounded polls back to back in the same active
+       turn until one returns `feedback` or `closed`.
+
+     Know the limit: this is reliable only while your turn stays active. A
+     turn that has already ended is not woken when the user hits Send; the
+     user has to message you, and you then run `status` and `poll` to pick
+     the batch up. There is no integration that resumes an ended task when
+     the poll exits.
 
    If it prints `{"status":"closed"}`, the review is over: the user ended it,
    closed the tab, or never had one open (`reason` says which). Stop and do

--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -35,17 +35,21 @@ keeping its formatting syntax.
    npx -y human-review poll path/to/file.html
    ```
 
-   Start it **in the background** and end your turn (in Claude Code, run it
-   with `run_in_background: true`). The command exits only when the user
-   clicks Send or closes the review, and your harness wakes you when it does —
-   so there is nothing to re-run, no interval to poll on, and no `--timeout`
-   to add. One background poll per review is the whole wait. It survives the
-   local server restarting, and feedback is saved even if the poll dies, so
-   nothing is ever lost.
+   The command exits only when the user clicks Send or closes the review.
+   There is nothing to re-run, no interval to poll on, and no `--timeout` to
+   add. It survives the local server restarting, and feedback is saved even
+   if the poll dies, so nothing is ever lost. How you wait depends on your
+   harness:
 
-   Only if your harness cannot wake you when a background command exits, run
-   the same command in the foreground instead and keep waiting on it (or on
-   the process handle it returns) until it exits.
+   - **Claude Code:** run it with `run_in_background: true` and end your turn.
+     Claude Code wakes you with the output the moment the command exits.
+   - **Codex, Cursor, and everything else:** run it in the **foreground** and
+     stay on it until it exits. Do not detach it or start it as a background
+     session — nothing will wake you when a detached command finishes, and
+     the user's Send will sit unread until they nudge you. If your shell tool
+     enforces a maximum command duration, pass `--timeout` a little under
+     that limit and run the same command again when it prints
+     `{"status":"timeout"}`.
 
    If it prints `{"status":"closed"}`, the review is over: the user ended it,
    closed the tab, or never had one open (`reason` says which). Stop and do

--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -47,9 +47,14 @@ keeping its formatting syntax.
    the same command in the foreground instead and keep waiting on it (or on
    the process handle it returns) until it exits.
 
-   If it prints `{"status":"closed"}`, the user ended the review from the
-   browser — stop and do not start another poll. Unsent feedback is kept and
-   ships the next time this target is reviewed.
+   If it prints `{"status":"closed"}`, the review is over: the user ended it,
+   closed the tab, or never had one open (`reason` says which). Stop and do
+   not start another poll. `unsent` counts feedback they left behind; if it is
+   not zero, tell the user in one line that it is kept and they can restore or
+   discard it next time. `{"status":"superseded"}` means a newer poll of
+   yours owns the wait — stop this one silently. `{"status":"timeout"}` only
+   appears after 12 hours; run `status` and start the wait again if the
+   review is still open.
 
 4. Apply what comes back, then start the next background poll. `--ack` clears
    the batch you just handled:
@@ -80,6 +85,7 @@ One batch covers every page the user visited, grouped by file or localhost URL.
   "pages": [
     {
       "file": "/abs/path/to/page.html",
+      "edits_saved": true,
       "comments": [
         { "id": "c_1", "kind": "selection", "quote": "the exact text they selected",
           "anchor": { "prefix": "...", "quote": "...", "suffix": "..." },
@@ -103,6 +109,16 @@ One batch covers every page the user visited, grouped by file or localhost URL.
   carry it across verbatim and never revert it. If the HTML was generated from
   something else (MDX, Markdown, a template), apply `after` to the **source** too,
   or their fix disappears on the next build.
+- **`edits_saved: true` means those edits are already in the file on disk.**
+  Plain HTML files autosave as the user types, so your copy of the file is
+  stale. Re-read the file before touching it and make targeted changes only;
+  never regenerate it from what you wrote earlier, or their work disappears.
+  `edits_saved: false` (Markdown, localhost pages, self-rendering HTML) means the
+  edits exist only in this batch — apply them to the source yourself.
+- An edit with `kind: "deleted"` means the user removed that whole block:
+  delete it from the source too, without asking why.
+- An edit marked `truncated: true` had its text cut at 200k characters; read
+  the block from the page itself rather than from `after_html`.
 - When `before_html`/`after_html` are present, the user changed formatting, not
   just words — bold, italic, underline, links. Use the HTML version to carry the
   formatting into the source, translated to its syntax (e.g. `<strong>` → `**`
@@ -123,10 +139,16 @@ One batch covers every page the user visited, grouped by file or localhost URL.
 - An edit with `kind: "moved"` means the user relocated that whole block.
   Reposition it in the source without rewriting its content: it now sits right
   after the block whose text starts with `moved_after`, and right before the
-  block whose text starts with `moved_before`. An empty `moved_after` means it
-  is now the first block in its container.
-- Find each comment by its `quote`; that exact string is in the file.
+  block whose text starts with `moved_before` (both are clipped to 90
+  characters and may end in `…`). An empty `moved_after` means it is now the
+  first block in its container.
+- Find each comment by its `quote`. It is the **rendered** text the user
+  selected, so in Markdown or templated HTML it may span formatting syntax or
+  tags; `anchor.prefix` and `anchor.suffix` give the surrounding text to
+  disambiguate.
 - `kind: "element"` points at a whole block, so `quote` is its label, not body text.
+- Copy any `staged_assets` files before you ack: `--ack` deletes them.
+- A batch with only an `overall_note` has an empty `pages` array.
 - Fix every page in `pages`, not just the first.
 - **Do not write a reply.** There is no chat. The user sees your work when the page
   reloads, which happens on its own the moment you save the file.

--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -28,32 +28,40 @@ keeping its formatting syntax.
    npx -y human-review http://localhost:3000/wiki
    ```
 
-3. Wait for feedback. This blocks until they hit Send, or the timeout passes:
+3. Wait for feedback. This command blocks until the user hits Send in the
+   browser, then prints their batch and exits:
 
    ```sh
-   npx -y human-review poll path/to/file.html --timeout 600
+   npx -y human-review poll path/to/file.html
    ```
 
-   Keep this command in the foreground. Do not end your turn while it is waiting.
-   If your shell returns a process or session handle, keep waiting on that handle
-   until the command exits. If it prints `{"status":"timeout"}`, no feedback has
-   arrived yet — run the same poll command again to keep waiting. Feedback is
-   saved even if a poll dies, so nothing is ever lost.
+   Start it **in the background** and end your turn (in Claude Code, run it
+   with `run_in_background: true`). The command exits only when the user
+   clicks Send or closes the review, and your harness wakes you when it does —
+   so there is nothing to re-run, no interval to poll on, and no `--timeout`
+   to add. One background poll per review is the whole wait. It survives the
+   local server restarting, and feedback is saved even if the poll dies, so
+   nothing is ever lost.
+
+   Only if your harness cannot wake you when a background command exits, run
+   the same command in the foreground instead and keep waiting on it (or on
+   the process handle it returns) until it exits.
 
    If it prints `{"status":"closed"}`, the user ended the review from the
-   browser — stop polling and do not run the poll command again. Unsent
-   feedback is kept and ships the next time this target is reviewed.
+   browser — stop and do not start another poll. Unsent feedback is kept and
+   ships the next time this target is reviewed.
 
-4. Apply what comes back, then wait again. `--ack` clears the batch you just handled:
+4. Apply what comes back, then start the next background poll. `--ack` clears
+   the batch you just handled:
 
    ```sh
-   npx -y human-review poll path/to/file.html --ack --timeout 600
+   npx -y human-review poll path/to/file.html --ack
    ```
 
 Repeat 3–4 until the user says they are done.
 
-Not sure whether feedback is already waiting — say, at the start of a new turn?
-This answers instantly without blocking:
+Not sure whether feedback is already waiting — say, at the start of a new turn
+with no poll running? This answers instantly without blocking:
 
 ```sh
 npx -y human-review status path/to/file.html

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -6,6 +6,7 @@
  */
 import { tidy } from "./anchor-text.js";
 import { pageUrl, replacePage } from "./chrome-session.js";
+import { normalizeHref } from "./editing.js";
 import { framePolicy } from "./frame-policy.js";
 
 const $ = (id) => document.getElementById(id);
@@ -607,9 +608,14 @@ window.addEventListener("message", async (event) => {
     case "eh:scroll":
       state.scroll = { x: msg.x, y: msg.y };
       break;
-    case "eh:external":
-      window.open(msg.href, "_blank", "noopener");
+    case "eh:external": {
+      // This side is what actually calls window.open, so it re-checks the
+      // scheme rather than trusting the frame: a javascript: or data: URL
+      // arriving here would run on this origin, next to the token.
+      const external = normalizeHref(msg.href);
+      if (external) window.open(external, "_blank", "noopener");
       break;
+    }
     case "eh:navigate":
       try {
         const result = await api(`/api/session/${state.sessionId}/navigate`, {

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -39,6 +39,8 @@ const state = {
   reloading: false,
   dynamic: false,
   framePolicy: null,
+  artifactToken: "",
+  leftover: null,
 };
 
 /**
@@ -49,7 +51,7 @@ const state = {
 function handoffPrompt(pollCommand) {
   const cmd = String(pollCommand || "").trim();
   if (!cmd) return "";
-  return `Run \`${cmd} --timeout 600\`, apply the feedback it returns, then keep polling with --ack until I end the review.`;
+  return `Start \`${cmd}\` in the background and end your turn; it exits when I hit Send. Apply the feedback it prints, then start it again with --ack.`;
 }
 
 // ------------------------------------------------------------------- server
@@ -80,7 +82,26 @@ const toFrame = (message) =>
 
 function artifactUrl(key, bust = false) {
   const query = bust ? `?t=${Date.now()}` : "";
-  return `${ARTIFACT_ORIGIN}/artifact/${key}/index.html${query}`;
+  return `${ARTIFACT_ORIGIN}/artifact/${state.artifactToken}/${key}/index.html${query}`;
+}
+
+/**
+ * The server forgot this session — it restarted, or the tab was away longer
+ * than the session lives. Open a fresh session on the same target so the
+ * page keeps working instead of turning into a dead tab that looks alive.
+ */
+async function rebootstrap() {
+  const target = state.page ? state.page.url || state.page.file : "";
+  if (!target) return false;
+  try {
+    const fresh = await api("/api/session", { method: "POST", body: JSON.stringify({ target }) });
+    state.sessionId = fresh.sessionId;
+    state.artifactToken = fresh.artifactToken || state.artifactToken;
+    history.replaceState(null, "", fresh.path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -185,8 +206,15 @@ function render() {
     sep.textContent = "·";
     const when = document.createElement("span");
     when.className = "when";
-    when.textContent = ago(comment.createdAt);
+    when.textContent = ago(comment.updatedAt || comment.createdAt);
     who.append(sep, when);
+
+    if (comment.updatedAt) {
+      const badge = document.createElement("span");
+      badge.className = "badge";
+      badge.textContent = "edited";
+      who.append(badge);
+    }
 
     if (state.orphans.has(comment.id)) {
       const badge = document.createElement("span");
@@ -204,6 +232,15 @@ function render() {
       setActive(comment.id, true);
     });
 
+    const edit = document.createElement("button");
+    edit.type = "button";
+    edit.className = "jump edit-comment";
+    edit.textContent = "Edit";
+    edit.addEventListener("click", (event) => {
+      event.stopPropagation();
+      editComment(card, body, comment);
+    });
+
     const remove = document.createElement("button");
     remove.type = "button";
     remove.className = "remove";
@@ -216,8 +253,6 @@ function render() {
       state.page = (await api(`/api/page/${state.key}/comment/${comment.id}`, { method: "DELETE" })).page;
       render();
     });
-
-    head.append(who, jump, remove);
 
     const quote = document.createElement("p");
     quote.className = "quote";
@@ -232,6 +267,7 @@ function render() {
       editComment(card, body, comment);
     });
 
+    head.append(who, jump, edit, remove);
     card.append(head, quote, body);
     card.addEventListener("click", () => setActive(comment.id, false));
     list.append(card);
@@ -314,20 +350,25 @@ function render() {
   const hasNote = $("note").value.trim().length > 0;
   const send = $("send");
   const delivered = state.agent === "working";
+  const queued = state.agent === "queued";
   const stranded = state.agent === "stranded";
-  const busy = delivered || stranded || state.sent;
+  // While the agent works, anything new can still be sent: it queues behind
+  // the batch in flight and ships with the agent's next poll.
+  const busy = stranded || state.sent || (queued && total === 0 && !hasNote);
   send.disabled = (total === 0 && !hasNote) || busy;
-  send.textContent = delivered
-    ? "Feedback delivered"
-    : stranded
-      ? "Sent — agent is not listening"
-      : state.sent
-        ? "Sent — waiting for agent"
-        : total
-          ? `Send ${total} to agent`
-          : hasNote
-            ? "Send note to agent"
-            : "Nothing to send yet";
+  send.textContent = stranded
+    ? "Sent — agent is not listening"
+    : state.sent
+      ? queued
+        ? "Sent — queued for the agent"
+        : delivered
+          ? "Feedback delivered"
+          : "Sent — waiting for agent"
+      : total
+        ? `Send ${total} to agent`
+        : hasNote
+          ? "Send note to agent"
+          : "Nothing to send yet";
   if (!send.disabled) {
     const key = document.createElement("span");
     key.className = "key";
@@ -337,8 +378,23 @@ function render() {
 
   // After sending, say what happens next. If nothing is polling, the loop would
   // otherwise dead-end silently, so hand over the exact command to run.
-  $("agentLine").hidden = !delivered;
-  $("agentText").textContent = "Feedback delivered — page reloads when fixes land";
+  $("agentLine").hidden = !(delivered || queued);
+  $("agentText").textContent = queued
+    ? "Agent is still on your last batch — this one ships with its next poll"
+    : "Feedback delivered — page reloads when fixes land";
+
+  // --- feedback left over from an earlier review of this page
+  const leftover = state.leftover;
+  const leftoverBox = $("leftover");
+  const leftoverTotal = leftover ? leftover.comments + leftover.edits : 0;
+  leftoverBox.hidden = !leftoverTotal;
+  if (leftoverTotal) {
+    const parts = [];
+    if (leftover.comments) parts.push(`${leftover.comments} ${leftover.comments === 1 ? "comment" : "comments"}`);
+    if (leftover.edits) parts.push(`${leftover.edits} ${leftover.edits === 1 ? "edit" : "edits"}`);
+    const savedNote = page.kind === "file" && !page.markdown ? " Text edits are already in the file either way." : "";
+    $("leftoverText").textContent = `${parts.join(" and ")} from your last review never went to the agent.${savedNote}`;
+  }
 
   // Server-authoritative, so it survives a browser refresh.
   $("handoff").hidden = !stranded;
@@ -389,11 +445,19 @@ function editComment(card, body, comment) {
     const feedback = input.value.trim();
     if (!feedback || feedback === comment.feedback) return render();
     try {
-      state.page = (await api(`/api/page/${state.key}/comment/${comment.id}`, {
+      const result = await api(`/api/page/${state.key}/comment/${comment.id}`, {
         method: "PATCH",
         body: JSON.stringify({ feedback }),
-      })).page;
-      state.sent = false;
+      });
+      state.page = result.page;
+      if (result.delivery === "updated-pending") toast("Updated the feedback waiting for your agent");
+      else if (result.delivery === "resend") {
+        state.sent = false;
+        toast("The agent already has the old wording — this version ships with your next Send");
+        // The retired id no longer marks anything; the new one takes over.
+        toFrame({ type: "eh:remove", id: comment.id });
+        toFrame({ type: "eh:anchors", comments: state.page.comments });
+      } else state.sent = false;
     } catch (err) {
       toast(err.message);
     }
@@ -418,12 +482,41 @@ function editComment(card, body, comment) {
   input.setSelectionRange(input.value.length, input.value.length);
 }
 
-function toast(message) {
+function toast(message, { action = "", onAction = null, ms = 3200 } = {}) {
   const el = document.createElement("div");
   el.className = "toast";
   el.textContent = message;
+  if (action && onAction) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "toast-action";
+    button.textContent = action;
+    button.addEventListener("click", () => {
+      el.remove();
+      onAction();
+    });
+    el.append(button);
+  }
   document.body.append(el);
-  setTimeout(() => el.remove(), 3200);
+  setTimeout(() => el.remove(), ms);
+}
+
+/**
+ * Edit rows post asynchronously; an undo must land after the row it reverses,
+ * or the DELETE clears nothing and the row ships anyway.
+ */
+let editChain = Promise.resolve();
+
+function undoBlock(label, kind) {
+  toFrame({ type: "eh:undo", label, kind });
+  editChain = editChain.then(async () => {
+    try {
+      state.page = (await api(`/api/page/${state.key}/edit`, { method: "DELETE", body: JSON.stringify({ label, kind }) })).page;
+      render();
+    } catch (err) {
+      toast(err.message);
+    }
+  });
 }
 
 function setActive(id, scroll) {
@@ -564,22 +657,32 @@ window.addEventListener("message", async (event) => {
       toast("That comment is not visible in this view");
       break;
     case "eh:edit":
-      state.page = (await api(`/api/page/${state.key}/edit`, {
-        method: "POST",
-        body: JSON.stringify({
-          label: msg.label,
-          kind: msg.kind,
-          before: msg.before,
-          after: msg.after,
-          before_html: msg.before_html,
-          after_html: msg.after_html,
-          moved_after: msg.moved_after,
-          moved_before: msg.moved_before,
-          staged_assets: msg.staged_assets,
-        }),
-      })).page;
-      state.sent = false;
-      render();
+      editChain = editChain.then(async () => {
+        state.page = (await api(`/api/page/${state.key}/edit`, {
+          method: "POST",
+          body: JSON.stringify({
+            label: msg.label,
+            kind: msg.kind,
+            before: msg.before,
+            after: msg.after,
+            before_html: msg.before_html,
+            after_html: msg.after_html,
+            moved_after: msg.moved_after,
+            moved_before: msg.moved_before,
+            staged_assets: msg.staged_assets,
+          }),
+        })).page;
+        state.sent = false;
+        render();
+      });
+      await editChain.catch((err) => toast(err.message));
+      break;
+    case "eh:undoable":
+      toast(msg.kind === "moved" ? `Moved “${tidy(msg.label, 40)}”` : `Deleted “${tidy(msg.label, 40)}”`, {
+        action: "Undo",
+        ms: 8000,
+        onAction: () => undoBlock(msg.label, msg.kind),
+      });
       break;
     case "eh:asset":
       try {
@@ -609,7 +712,11 @@ window.addEventListener("message", async (event) => {
       renderSave();
       break;
     case "eh:dynamic":
-      state.dynamic = true;
+      if (!state.dynamic) {
+        state.dynamic = true;
+        // The batch says whether edits are on disk; a self-rendering page's are not.
+        api(`/api/page/${state.key}/mode`, { method: "POST", body: JSON.stringify({ dynamic: true }) }).catch(() => {});
+      }
       renderSave();
       break;
     case "eh:flushed":
@@ -701,8 +808,23 @@ $("revert").addEventListener("click", async () => {
   }
 });
 
+$("leftoverKeep").addEventListener("click", () => {
+  state.leftover = null;
+  render();
+});
+
+$("leftoverDiscard").addEventListener("click", async () => {
+  try {
+    await api(`/api/page/${state.key}/discard`, { method: "POST" });
+    state.leftover = null;
+    await loadPage(state.key);
+  } catch (err) {
+    toast(err.message);
+  }
+});
+
 /** The session is over: freeze the page and say so. Feedback is already safe. */
-function showEnded() {
+function showEnded(message) {
   if (document.querySelector(".ended")) return;
   if (events) events.close();
   clearTimeout(retryTimer);
@@ -711,10 +833,23 @@ function showEnded() {
   const title = document.createElement("h2");
   title.textContent = "Review ended";
   const line = document.createElement("p");
-  line.textContent = "Unsent feedback is saved and ships next time you review this page. You can close this tab.";
+  line.textContent = message || "Unsent feedback is kept; next time you open this page you can restore or discard it. You can close this tab.";
   overlay.append(title, line);
   document.body.append(overlay);
 }
+
+// A closing tab says so, and the review ends unless it comes right back (a
+// reload). keepalive lets the request outlive the page; sendBeacon cannot
+// carry the token header.
+window.addEventListener("pagehide", () => {
+  try {
+    fetch(`/api/session/${state.sessionId}/away`, {
+      method: "POST",
+      keepalive: true,
+      headers: { "x-human-review-token": state.token },
+    }).catch(() => {});
+  } catch {}
+});
 
 $("endReview").addEventListener("click", async () => {
   const page = state.page;
@@ -806,8 +941,15 @@ let events = null;
 function connect() {
   const source = new EventSource(`/events/${state.sessionId}`);
   events = source;
-  // Another window on this session hit End review.
-  source.addEventListener("ended", () => showEnded());
+  // Another window on this session hit End review, or the server gave up on
+  // a tab that never came back.
+  source.addEventListener("ended", (event) => {
+    let reason = "ended";
+    try {
+      reason = JSON.parse(event.data).reason || reason;
+    } catch {}
+    showEnded(reason === "window_closed" ? "This tab was away too long, so the review ended. Unsent feedback is kept; reopen the page to restore or discard it." : undefined);
+  });
   source.addEventListener("reload", () => {
     const hadEdits = state.page ? state.page.edits.length : 0;
     state.reloading = true;
@@ -837,7 +979,14 @@ function connect() {
     render();
   });
   source.onerror = () => {
-    /* EventSource reconnects on its own. */
+    // A dropped connection reconnects on its own. A refused one (the server
+    // forgot this session) never will, so open a fresh session instead.
+    if (source.readyState !== EventSource.CLOSED) return;
+    source.close();
+    rebootstrap().then((ok) => {
+      if (ok) connect();
+      else showEnded("This review session expired. Run human-review on this page again to reopen it.");
+    });
   };
 }
 
@@ -850,8 +999,14 @@ function connect() {
   } catch {}
 
   const bootstrap = await api(`/api/session/${state.sessionId}/page`).catch(() => null);
-  if (bootstrap && bootstrap.page) state.pollCommand = bootstrap.page.pollCommand;
-  const key = bootstrap ? bootstrap.key : new URLSearchParams(location.search).get("key");
-  await loadPage(key);
+  if (!bootstrap) {
+    showEnded("This review session has ended. Run human-review on the page again to reopen it.");
+    return;
+  }
+  if (bootstrap.page) state.pollCommand = bootstrap.page.pollCommand;
+  state.artifactToken = bootstrap.artifactToken || "";
+  const leftover = bootstrap.leftover || { comments: 0, edits: 0 };
+  state.leftover = leftover.comments + leftover.edits ? leftover : null;
+  await loadPage(bootstrap.key);
   connect();
 })();

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -147,6 +147,7 @@ const clock = () => new Date().toLocaleTimeString([], { hour: "numeric", minute:
 function render() {
   const page = state.page;
   if (!page) return;
+  document.title = page.filename || 'human-review';
 
   const comments = page.comments || [];
   const edits = page.edits || [];

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -650,7 +650,9 @@ $("composeCancel").addEventListener("click", cancelCompose);
 
 // Clicking anywhere on the card is the "I meant to comment" gesture.
 $("compose").addEventListener("mousedown", (event) => {
-  if (event.target.closest("button")) return;
+  // The textarea handles its own clicks — swallowing them would pin the caret
+  // to the end and make repositioning it impossible.
+  if (event.target.closest("button, textarea")) return;
   event.preventDefault();
   $("composeText").focus();
 });

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -823,8 +823,12 @@ $("leftoverDiscard").addEventListener("click", async () => {
   }
 });
 
+/** Once the review is over or the tab is leaving, nothing may open a new session. */
+let finished = false;
+
 /** The session is over: freeze the page and say so. Feedback is already safe. */
 function showEnded(message) {
+  finished = true;
   if (document.querySelector(".ended")) return;
   if (events) events.close();
   clearTimeout(retryTimer);
@@ -842,6 +846,8 @@ function showEnded(message) {
 // reload). keepalive lets the request outlive the page; sendBeacon cannot
 // carry the token header.
 window.addEventListener("pagehide", () => {
+  finished = true;
+  if (events) events.close();
   try {
     fetch(`/api/session/${state.sessionId}/away`, {
       method: "POST",
@@ -981,9 +987,10 @@ function connect() {
   source.onerror = () => {
     // A dropped connection reconnects on its own. A refused one (the server
     // forgot this session) never will, so open a fresh session instead.
-    if (source.readyState !== EventSource.CLOSED) return;
+    if (source.readyState !== EventSource.CLOSED || finished) return;
     source.close();
     rebootstrap().then((ok) => {
+      if (finished) return;
       if (ok) connect();
       else showEnded("This review session expired. Run human-review on this page again to reopen it.");
     });

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -9,6 +9,14 @@ import { pageUrl, replacePage } from "./chrome-session.js";
 import { normalizeHref } from "./editing.js";
 import { framePolicy } from "./frame-policy.js";
 
+/**
+ * True when an "Enter" keydown is really an IME confirming its composition
+ * (e.g. finalizing kanji conversion), not the user asking to submit.
+ */
+function isImeCommitEnter(event) {
+  return Boolean(event.isComposing || event.keyCode === 229);
+}
+
 const $ = (id) => document.getElementById(id);
 const frame = $("frame");
 
@@ -393,6 +401,7 @@ function editComment(card, body, comment) {
   input.addEventListener("keydown", (event) => {
     event.stopPropagation();
     if (event.key === "Enter" && !event.shiftKey) {
+      if (isImeCommitEnter(event)) return;
       event.preventDefault();
       commit();
     }
@@ -647,6 +656,7 @@ $("compose").addEventListener("mousedown", (event) => {
 
 $("composeText").addEventListener("keydown", (event) => {
   if (event.key === "Enter" && !event.shiftKey) {
+    if (isImeCommitEnter(event)) return;
     event.preventDefault();
     commitCompose();
   }
@@ -771,6 +781,7 @@ function applyTheme(dark) {
 document.addEventListener("keydown", (event) => {
   const meta = event.metaKey || event.ctrlKey;
   if (meta && event.key === "Enter") {
+    if (isImeCommitEnter(event)) return;
     event.preventDefault();
     if (!$("send").disabled) $("send").click();
     return;

--- a/src/chrome.css
+++ b/src/chrome.css
@@ -454,3 +454,33 @@ body.collapsed .handle { right: 0; }
 @media (prefers-reduced-motion: reduce) {
   *, .rail, .handle { animation: none !important; transition: none !important; }
 }
+
+/* An undo-able action: the toast carries the button. */
+.toast-action {
+  margin-left: 12px;
+  padding: 3px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.toast-action:hover { background: rgba(255, 255, 255, 0.14); }
+:root[data-theme="dark"] .toast-action { border-color: rgba(0, 0, 0, 0.25); }
+:root[data-theme="dark"] .toast-action:hover { background: rgba(0, 0, 0, 0.1); }
+
+/* Feedback left behind by a review that ended without a Send. */
+.leftover {
+  margin: 10px 12px 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--strong-border);
+  border-radius: 9px;
+  background: var(--soft);
+}
+.leftover p { margin: 0 0 8px; font-size: 12px; line-height: 1.45; color: var(--txt); }
+.leftover-actions { display: flex; gap: 6px; }
+.leftover-actions .btn-ghost { padding: 4px 10px; font-size: 12px; }
+
+.edit-comment { margin-left: 0; }

--- a/src/chrome.html
+++ b/src/chrome.html
@@ -12,7 +12,7 @@
       <iframe
         id="frame"
         title="Artifact under review"
-        sandbox="allow-scripts allow-forms allow-modals allow-popups allow-downloads"></iframe>
+        sandbox="allow-scripts allow-forms allow-modals"></iframe>
     </main>
 
     <button type="button" id="handle" class="handle" title="Hide comments panel" aria-label="Hide comments panel">›</button>

--- a/src/chrome.html
+++ b/src/chrome.html
@@ -25,6 +25,14 @@
           <button type="button" id="theme" class="icon-btn" title="Switch chrome to dark" aria-label="Switch chrome to dark">☾</button>
         </div>
 
+        <div id="leftover" class="leftover" hidden>
+          <p id="leftoverText"></p>
+          <div class="leftover-actions">
+            <button type="button" id="leftoverKeep" class="btn-ghost">Keep</button>
+            <button type="button" id="leftoverDiscard" class="btn-ghost danger-hover">Discard</button>
+          </div>
+        </div>
+
         <div id="compose" hidden>
           <div class="compose">
             <div class="compose-head">

--- a/src/cli.js
+++ b/src/cli.js
@@ -226,7 +226,9 @@ async function pollCommand(input, { ack = false, timeoutSecs = 0 } = {}) {
       failures += 1;
       if (bounded && failures >= 3) break;
       process.stderr.write(`Lost the connection (${err.message}); reconnecting.\n`);
-      await sleep(Math.min(2000 * failures, 10000));
+      // Long enough for a replacement server to announce itself first, so
+      // this does not race it by spawning a second one.
+      await sleep(Math.min(3000 * failures, 10000));
       server = await ensureServer();
       continue;
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -178,12 +178,16 @@ function writeStdout(text) {
   return new Promise((resolve) => process.stdout.write(text, resolve));
 }
 
-function printTimeout(waitedSecs) {
+/** An open-ended wait still ends eventually: a forgotten tab must not pin a process for days. */
+const MAX_OPEN_WAIT_MS = 12 * 60 * 60 * 1000;
+
+function printTimeout(waitedSecs, { capped = false } = {}) {
   const payload = {
     status: "timeout",
     waited_seconds: waitedSecs,
-    next_step:
-      "No feedback yet. Run the same poll command again to keep waiting, or `human-review status <target>` to check without blocking.",
+    next_step: capped
+      ? "Nothing arrived in 12 hours. Run `human-review status <target>`: if the review is still open, start the same background poll again; otherwise stop."
+      : "No feedback yet. Run the same poll command again to keep waiting, or `human-review status <target>` to check without blocking.",
   };
   return writeStdout(`${JSON.stringify(payload, null, 2)}\n`);
 }
@@ -205,26 +209,29 @@ async function pollCommand(input, { ack = false, timeoutSecs = 0 } = {}) {
   const label = /^https?:\/\//i.test(target) ? target : path.basename(target);
   process.stderr.write(`Waiting for feedback on ${label} — comment in the browser, then hit Send.\n`);
 
-  const deadline = timeoutSecs ? Date.now() + timeoutSecs * 1000 : null;
+  const bounded = timeoutSecs > 0;
+  const started = Date.now();
+  const deadline = bounded ? started + timeoutSecs * 1000 : started + MAX_OPEN_WAIT_MS;
+  const timedOut = () => printTimeout(bounded ? timeoutSecs : Math.round((Date.now() - started) / 1000), { capped: !bounded });
   // The ack rides on the first request that actually reaches the server.
   let ackPending = ack;
   let failures = 0;
   for (;;) {
-    const remaining = deadline ? deadline - Date.now() : 0;
-    if (deadline && remaining <= 0) return printTimeout(timeoutSecs);
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return timedOut();
     let result;
     try {
       result = await pollOnce(server, target, ackPending, remaining);
     } catch (err) {
       failures += 1;
-      if (deadline && failures >= 3) break;
+      if (bounded && failures >= 3) break;
       process.stderr.write(`Lost the connection (${err.message}); reconnecting.\n`);
       await sleep(Math.min(2000 * failures, 10000));
       server = await ensureServer();
       continue;
     }
     ackPending = false;
-    if (result.kind === "timeout") return printTimeout(timeoutSecs);
+    if (result.kind === "timeout") return timedOut();
     if (result.raw) {
       try {
         const batch = JSON.parse(result.raw);
@@ -237,7 +244,7 @@ async function pollCommand(input, { ack = false, timeoutSecs = 0 } = {}) {
     // An empty or garbled answer means the server closed the request without
     // a batch; wait a beat so a misbehaving server cannot spin this loop.
     failures += 1;
-    if (deadline && failures >= 3) break;
+    if (bounded && failures >= 3) break;
     await sleep(500);
   }
   process.stderr.write("Gave up waiting for feedback.\n");

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,9 +13,9 @@ const pkg = JSON.parse(fs.readFileSync(path.join(here, "..", "package.json"), "u
 const HELP = `human-review ${pkg.version}
 
   human-review <file-or-localhost-url> Open a file or localhost page for review
-  human-review poll <target>          Wait for feedback, print it as JSON (for agents)
-      --ack                        Acknowledge the last batch, then keep waiting
-      --timeout <secs>             Exit with {"status":"timeout"} if nothing arrives
+  human-review poll <target>          Block until the user hits Send, then print the batch as JSON
+      --ack                        Acknowledge the last batch, then wait for the next
+      --timeout <secs>             Give up with {"status":"timeout"} after this long (default: wait for Send)
   human-review status <target>        Report whether feedback is waiting, without blocking
   human-review setup                  Teach Claude Code / Codex how to use human-review
   human-review setup --global         ...for every project, not just this one
@@ -119,7 +119,7 @@ async function openCommand(input) {
   openBrowser(url);
   console.log(`Reviewing ${target.kind === "url" ? target.value : path.basename(target.value)}`);
   console.log(url);
-  console.log(`\nWaiting for feedback? Run:\n  human-review poll ${shellQuote(target.value)}`);
+  console.log(`\nWaiting for feedback? Run this in the background; it exits when the user hits Send:\n  human-review poll ${shellQuote(target.value)}`);
 }
 
 /**
@@ -151,6 +151,11 @@ function pollOnce(server, target, ack, timeoutMs) {
           raw += chunk;
         });
         res.on("end", () => settle(resolve, { kind: "data", raw: raw.trim() }));
+        res.on("error", (err) => settle(reject, err));
+        // The server went away mid-wait: the socket closes without an 'end'.
+        // Left unhandled, the promise never settles and Node exits the
+        // process as soon as the loop drains — with the agent still asleep.
+        res.on("close", () => settle(reject, new Error("server connection closed")));
       }
     );
     const timer = timeoutMs
@@ -183,33 +188,57 @@ function printTimeout(waitedSecs) {
   return writeStdout(`${JSON.stringify(payload, null, 2)}\n`);
 }
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Without --timeout this is an open-ended wait: the agent parks this process
+ * in the background and is woken only when it exits, which should happen
+ * when the user hits Send or closes the review — never because the detached
+ * server went away underneath it (a newer CLI replaced it, or the machine
+ * slept). So a lost connection reconnects, restarting the server if needed,
+ * instead of giving up. A poll with a deadline keeps the old bounded retries.
+ */
 async function pollCommand(input, { ack = false, timeoutSecs = 0 } = {}) {
   const target = canonicalTarget(input).value;
-  const server = await ensureServer();
+  let server = await ensureServer();
 
   const label = /^https?:\/\//i.test(target) ? target : path.basename(target);
   process.stderr.write(`Waiting for feedback on ${label} — comment in the browser, then hit Send.\n`);
 
   const deadline = timeoutSecs ? Date.now() + timeoutSecs * 1000 : null;
-  for (let attempt = 0; attempt < 3; attempt += 1) {
+  // The ack rides on the first request that actually reaches the server.
+  let ackPending = ack;
+  let failures = 0;
+  for (;;) {
     const remaining = deadline ? deadline - Date.now() : 0;
     if (deadline && remaining <= 0) return printTimeout(timeoutSecs);
     let result;
     try {
-      result = await pollOnce(server, target, ack && attempt === 0, remaining);
+      result = await pollOnce(server, target, ackPending, remaining);
     } catch (err) {
-      process.stderr.write(`Lost the connection (${err.message}); retrying.\n`);
+      failures += 1;
+      if (deadline && failures >= 3) break;
+      process.stderr.write(`Lost the connection (${err.message}); reconnecting.\n`);
+      await sleep(Math.min(2000 * failures, 10000));
+      server = await ensureServer();
       continue;
     }
+    ackPending = false;
     if (result.kind === "timeout") return printTimeout(timeoutSecs);
-    if (!result.raw) continue;
-    try {
-      const batch = JSON.parse(result.raw);
-      await writeStdout(`${JSON.stringify(batch, null, 2)}\n`);
-      return;
-    } catch {
-      process.stderr.write("Unexpected response from the human-review server; retrying.\n");
+    if (result.raw) {
+      try {
+        const batch = JSON.parse(result.raw);
+        await writeStdout(`${JSON.stringify(batch, null, 2)}\n`);
+        return;
+      } catch {
+        process.stderr.write("Unexpected response from the human-review server; retrying.\n");
+      }
     }
+    // An empty or garbled answer means the server closed the request without
+    // a batch; wait a beat so a misbehaving server cannot spin this loop.
+    failures += 1;
+    if (deadline && failures >= 3) break;
+    await sleep(500);
   }
   process.stderr.write("Gave up waiting for feedback.\n");
   process.exit(1);

--- a/src/frame-policy.js
+++ b/src/frame-policy.js
@@ -1,4 +1,4 @@
-const BASE_SANDBOX = "allow-scripts allow-forms allow-modals allow-popups allow-downloads";
+const BASE_SANDBOX = "allow-scripts allow-forms allow-modals";
 
 /**
  * Localhost apps need their real origin so their routing and JavaScript work.

--- a/src/html-transform.js
+++ b/src/html-transform.js
@@ -4,12 +4,26 @@ const SDK_TAG_RE = /<script[^>]*\bdata-eh-sdk\b[^>]*><\/script>/gi;
 const SDK_BASE_RE = /<base[^>]*\bdata-eh-sdk\b[^>]*>/gi;
 const SDK_ROUTE_RE = /<script[^>]*\bdata-eh-route\b[^>]*>[\s\S]*?<\/script>/gi;
 const ASSET_TAG_RE = /<(script|link|img|source|video|audio|iframe|embed|object)\b[^>]*>/gi;
-const ASSET_ATTR_RE = /(\s)(src|href|poster|data)=(['"])(.*?)\3/gi;
+const ASSET_ATTR_RE = /(\s)(src|href|poster|data|srcset)=(['"])(.*?)\3/gi;
+
+const skipUrl = (value) => !value || /^(?:data|blob|javascript):/i.test(value) || value.startsWith("#");
 
 function absolutizeAssets(html, baseHref) {
   return String(html).replace(ASSET_TAG_RE, (tag) =>
     tag.replace(ASSET_ATTR_RE, (attribute, space, name, quote, value) => {
-      if (!value || /^(?:data|blob|javascript):/i.test(value) || value.startsWith("#")) return attribute;
+      if (name.toLowerCase() === "srcset") {
+        // "a.png 1x, b.png 2x": each candidate is a URL followed by a descriptor.
+        const rewritten = value
+          .split(",")
+          .map((candidate) => {
+            const [url, ...descriptor] = candidate.trim().split(/\s+/);
+            if (skipUrl(url)) return candidate.trim();
+            return [new URL(url, baseHref).href, ...descriptor].join(" ");
+          })
+          .join(", ");
+        return `${space}${name}=${quote}${rewritten}${quote}`;
+      }
+      if (skipUrl(value)) return attribute;
       const absolute = new URL(value, baseHref).href;
       return `${space}${name}=${quote}${absolute}${quote}`;
     })

--- a/src/paths.js
+++ b/src/paths.js
@@ -5,7 +5,7 @@ import fs from "node:fs";
 
 // Bump this when the CLI and detached server no longer share the same request
 // contract. A new CLI must not silently reuse an older background server.
-export const SERVER_PROTOCOL = 8;
+export const SERVER_PROTOCOL = 9;
 
 export function stateDir() {
   const override = process.env.HUMAN_REVIEW_STATE_DIR;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -383,7 +383,8 @@ function targetFor(node) {
   }
 
   if (!pinnedLabels.has(block)) {
-    const heading = precedingHeading(block);
+    // A heading names itself; the heading before it would mislabel the edit.
+    const heading = /^h[1-6]$/i.test(block.tagName) ? "" : precedingHeading(block);
     const tag = block.tagName.toLowerCase();
     // Siblings of the same tag would otherwise share a label and collapse into
     // one edit row, so number them.
@@ -769,7 +770,8 @@ function boot() {
       }
 
       // Plain clicks belong to editing: never navigate, never fire artifact JS.
-      if (href || (event.target.closest && event.target.closest("button, [role='button'], summary"))) {
+      // A <summary> keeps its native toggle: collapsed content must stay reachable.
+      if (href || (event.target.closest && event.target.closest("button, [role='button']"))) {
         event.preventDefault();
         event.stopPropagation();
       }

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -364,6 +364,18 @@ const clip = (text, limit = 40) => {
  */
 const pinnedLabels = new WeakMap();
 
+/**
+ * Sibling order as the page loaded. Ordinals in labels ("p 3") come from
+ * here, so deleting a paragraph does not renumber the ones after it and hand
+ * two different blocks the same label within one review.
+ */
+const bootChildren = new WeakMap();
+function snapshotOrder() {
+  for (const el of document.body.querySelectorAll("*")) {
+    if (el.children.length > 1 && !isOurs(el)) bootChildren.set(el, [...el.children]);
+  }
+}
+
 /** The block a hover/edit belongs to, plus a human label for the edit list. */
 function targetFor(node) {
   const el = node && node.nodeType === 1 ? node : node && node.parentElement;
@@ -387,8 +399,12 @@ function targetFor(node) {
     const heading = /^h[1-6]$/i.test(block.tagName) ? "" : precedingHeading(block);
     const tag = block.tagName.toLowerCase();
     // Siblings of the same tag would otherwise share a label and collapse into
-    // one edit row, so number them.
-    const twins = block.parentElement ? [...block.parentElement.children].filter((c) => c.tagName === block.tagName) : [];
+    // one edit row, so number them — by their order at load, not right now.
+    const parent = block.parentElement;
+    const live = parent ? [...parent.children] : [];
+    const booted = parent ? bootChildren.get(parent) : null;
+    const siblings = booted && booted.includes(block) ? booted : live;
+    const twins = siblings.filter((c) => c.tagName === block.tagName);
     const ordinal = twins.length > 1 ? ` ${twins.indexOf(block) + 1}` : "";
     pinnedLabels.set(block, heading ? `${clip(heading, 26)} · ${tag}${ordinal}` : clip(block.textContent, 40) || tag);
   }
@@ -720,6 +736,7 @@ function boot() {
   // real app stays directly editable, not just its initial HTML response.
   keepBodyEditable(document.body);
   document.body.spellcheck = false;
+  snapshotOrder();
   baseline = serialize();
   bootSnapshot = baseline;
   watchSelfRendering();
@@ -918,12 +935,16 @@ function boot() {
    * "this paragraph became a list" instead of a row for an unknown block with
    * no `before`.
    */
-  const adoptIdentity = (from, to) => {
-    if (!from || !to || from === to) return;
-    if (!pinnedLabels.has(to) && pinnedLabels.has(from)) pinnedLabels.set(to, pinnedLabels.get(from));
-    if (!originalText.has(to) && originalText.has(from)) {
-      originalText.set(to, originalText.get(from));
-      originalHtml.set(to, originalHtml.get(from));
+  const adoptIdentity = (source, created) => {
+    if (!source || !created || created === source.el) return;
+    // The input event fired inside execCommand, before this ran, and the
+    // fresh element named itself ("li 3", no `before`). Retract that row.
+    const stale = pinnedLabels.get(created);
+    if (stale && stale !== source.label) editQueue.delete(`${stale}\u0000edited`);
+    pinnedLabels.set(created, source.label);
+    if (!originalText.has(created) && originalText.has(source.el)) {
+      originalText.set(created, originalText.get(source.el));
+      originalHtml.set(created, originalHtml.get(source.el));
     }
   };
 
@@ -935,8 +956,9 @@ function boot() {
     const el = node && (node.nodeType === 1 ? node : node.parentElement);
     const item = el && el.closest ? el.closest("li") : null;
     const list = item ? item.closest("ul, ol") : null;
-    adoptIdentity(source.el, item);
-    adoptIdentity(source.el, list);
+    adoptIdentity(source, item);
+    adoptIdentity(source, list);
+    if (item) emitBlockEdit(item, source.label);
   };
 
   /**

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -371,7 +371,7 @@ const pinnedLabels = new WeakMap();
  */
 const bootChildren = new WeakMap();
 function snapshotOrder() {
-  for (const el of document.body.querySelectorAll("*")) {
+  for (const el of [document.body, ...document.body.querySelectorAll("*")]) {
     if (el.children.length > 1 && !isOurs(el)) bootChildren.set(el, [...el.children]);
   }
 }

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -865,6 +865,12 @@ function boot() {
     scheduleSave();
   });
 
+  /**
+   * Delete and move are the two gestures with no native undo, so the last
+   * one is kept restorable: the element itself, detached, plus where it was.
+   */
+  let undoable = null; // { kind, el, parent, next, label }
+
   els.chipDelete.addEventListener("click", (event) => {
     event.preventDefault();
     event.stopPropagation();
@@ -873,13 +879,28 @@ function boot() {
     const target = targetFor(hoverTarget);
     const label = target ? target.label : "Element";
     const before = hoverTarget.textContent;
+    undoable = { kind: "deleted", el: hoverTarget, parent: hoverTarget.parentNode, next: hoverTarget.nextSibling, label };
     hoverTarget.remove();
     hoverTarget = null;
     place(els.outline, null);
     showChip(null);
     queueEdit({ label, kind: "deleted", before, after: "" });
     flushSave();
+    post("eh:undoable", { label, kind: "deleted" });
   });
+
+  const restoreBlock = (label, kind) => {
+    const undo = undoable;
+    undoable = null;
+    if (!undo || undo.label !== label || undo.kind !== kind) return;
+    if (!undo.parent || !undo.parent.isConnected) return;
+    const next = undo.next && undo.next.parentNode === undo.parent ? undo.next : null;
+    undo.parent.insertBefore(undo.el, next);
+    undo.el.style.opacity = "";
+    // The chrome drops the row; the block is back to its captured original,
+    // so there is nothing new to report — only the file to write again.
+    flushSave();
+  };
 
   // beforeinput still sees the untouched wording, so capture it once per block.
   const originalText = new WeakMap();
@@ -890,6 +911,64 @@ function boot() {
       originalHtml.set(el, blockHtml(el));
     }
   };
+
+  /**
+   * A list command replaces the paragraph with fresh <li>/<ul> elements. They
+   * inherit its label and captured original, so the edit row still reads
+   * "this paragraph became a list" instead of a row for an unknown block with
+   * no `before`.
+   */
+  const adoptIdentity = (from, to) => {
+    if (!from || !to || from === to) return;
+    if (!pinnedLabels.has(to) && pinnedLabels.has(from)) pinnedLabels.set(to, pinnedLabels.get(from));
+    if (!originalText.has(to) && originalText.has(from)) {
+      originalText.set(to, originalText.get(from));
+      originalHtml.set(to, originalHtml.get(from));
+    }
+  };
+
+  const afterListCommand = (source) => {
+    const sel = document.getSelection();
+    polishNewList(sel);
+    if (!source || source.authored) return;
+    const node = sel && sel.anchorNode;
+    const el = node && (node.nodeType === 1 ? node : node.parentElement);
+    const item = el && el.closest ? el.closest("li") : null;
+    const list = item ? item.closest("ul, ol") : null;
+    adoptIdentity(source.el, item);
+    adoptIdentity(source.el, list);
+  };
+
+  /**
+   * Every block a selection touches. Typing over a selection that runs from
+   * one paragraph into the next changes both — the second may vanish
+   * entirely — and each needs its own row.
+   */
+  const blocksInRange = (range) => {
+    const found = [];
+    const add = (node) => {
+      const target = targetFor(node);
+      if (target && !found.some((t) => t.el === target.el)) found.push(target);
+    };
+    add(range.startContainer);
+    add(range.endContainer);
+    if (range.collapsed) return found;
+    const root = range.commonAncestorContainer;
+    const scope = root.nodeType === 1 ? root : root.parentElement;
+    if (!scope) return found;
+    const walker = document.createTreeWalker(scope, NodeFilter.SHOW_ELEMENT, {
+      acceptNode: (el) => (isOurs(el) || !range.intersectsNode(el) ? NodeFilter.FILTER_REJECT : isBlock(el) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP),
+    });
+    let el = walker.nextNode();
+    let budget = 400;
+    while (el && budget > 0) {
+      add(el);
+      el = walker.nextNode();
+      budget -= 1;
+    }
+    return found;
+  };
+  let affected = null; // targets of a multi-block selection, until the input event reports them
 
   /** An edit row for a block changed outside the input-event flow (attribute
    * set, link removal, drag move) — the same shape the input listener emits. */
@@ -942,8 +1021,12 @@ function boot() {
       // From here on, DOM drift is the human typing, not the page rendering.
       userEdited = true;
       const sel = document.getSelection();
-      const target = targetFor(sel && sel.anchorNode ? sel.anchorNode : event.target);
+      const range = sel && sel.rangeCount ? sel.getRangeAt(0) : null;
+      const blocks = range ? blocksInRange(range) : [];
+      const target = blocks[0] || targetFor(event.target);
       if (target) captureOriginal(target.el);
+      for (const block of blocks) captureOriginal(block.el);
+      affected = blocks.length > 1 ? blocks : null;
     },
     true
   );
@@ -1119,7 +1202,7 @@ function boot() {
         userEdited = true;
         captureOriginal(target.el);
         document.execCommand(event.code === "Digit7" ? "insertOrderedList" : "insertUnorderedList");
-        polishNewList(document.getSelection());
+        afterListCommand(target);
         scheduleSave();
         return;
       }
@@ -1172,7 +1255,7 @@ function boot() {
         sel.addRange(lead);
         document.execCommand("delete");
         document.execCommand(command);
-        polishNewList(document.getSelection());
+        afterListCommand(target);
         scheduleSave();
       }
     },
@@ -1322,6 +1405,7 @@ function boot() {
     const next = drop.before ? drop.ref : drop.ref.nextElementSibling;
     if (next === el || (drop.before ? drop.ref.previousElementSibling : drop.ref) === el) return;
     userEdited = true;
+    undoable = { kind: "moved", el, parent: el.parentNode, next: el.nextSibling, label };
     drop.ref.parentNode.insertBefore(el, next);
     const prev = el.previousElementSibling;
     const following = el.nextElementSibling;
@@ -1336,6 +1420,7 @@ function boot() {
       moved_before: following ? clip(following.textContent, 90) : "",
     });
     flushSave();
+    post("eh:undoable", { label, kind: "moved" });
   });
 
   // ------------------------------------------------------------- image paste
@@ -1401,6 +1486,18 @@ function boot() {
     if (pending) {
       clearPending();
       post("eh:dismiss", {});
+    }
+    if (affected) {
+      // A selection spanning blocks: the first absorbed the rest, and any
+      // block that is gone now is a deletion in its own right.
+      const blocks = affected;
+      affected = null;
+      for (const block of blocks) {
+        if (block.el.isConnected) emitBlockEdit(block.el, block.label);
+        else queueEdit({ label: block.label, kind: "deleted", before: originalText.get(block.el), after: "", before_html: originalHtml.get(block.el), after_html: "" });
+      }
+      scheduleSave();
+      return;
     }
     const sel = document.getSelection();
     const node = sel && sel.anchorNode ? sel.anchorNode : event.target;
@@ -1510,6 +1607,9 @@ function boot() {
         break;
       case "eh:assetFailed":
         pendingPastes.delete(msg.id);
+        break;
+      case "eh:undo":
+        restoreBlock(String(msg.label || ""), String(msg.kind || ""));
         break;
       default:
         break;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -10,6 +10,14 @@ import { hashClickAction, navigationHref } from "./click-target.js";
 import { linkStyleFixup, listCommandFor, listStyleFixup, normalizeHref } from "./editing.js";
 import { keepBodyEditable, serializeDocument, UI_ATTR, MARK_ATTR } from "./serialize.js";
 
+/**
+ * True when an "Enter" keydown is really an IME confirming its composition
+ * (e.g. finalizing kanji conversion), not the user asking to submit.
+ */
+function isImeCommitEnter(event) {
+  return Boolean(event.isComposing || event.keyCode === 229);
+}
+
 const SAVE_DEBOUNCE_MS = 700;
 const EDIT_FLUSH_MS = 500;
 const MEDIA = /^(img|svg|canvas|video|picture|iframe|hr|figure)$/i;
@@ -1058,6 +1066,7 @@ function boot() {
   els.linkInput.addEventListener("keydown", (event) => {
     event.stopPropagation();
     if (event.key === "Enter") {
+      if (isImeCommitEnter(event)) return;
       event.preventDefault();
       applyLink();
     } else if (event.key === "Escape") {

--- a/src/server-entry.js
+++ b/src/server-entry.js
@@ -3,8 +3,11 @@ import { start } from "./server.js";
 const port = Number(process.env.HUMAN_REVIEW_PORT || 0);
 try {
   await start(port);
-} catch {
-  // start() already reported the cause (e.g. HUMAN_REVIEW_PORT in use).
+} catch (err) {
+  // Another server already owns this state directory: the CLI that spawned
+  // us finds it through server.json, so leaving quietly is the right answer.
+  if (err && err.code === "EALREADY") process.exit(0);
+  // start() already reported any other cause (e.g. HUMAN_REVIEW_PORT in use).
   process.exit(1);
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -41,6 +41,8 @@ const IDLE_SHUTDOWN_MS = Number(process.env.HUMAN_REVIEW_IDLE_MS || 45 * 60 * 10
 const SESSION_TTL_MS = 30 * 60 * 1000;
 /** After a tab says it is going away, how long a reload has to come back. */
 const CLOSE_GRACE_MS = Number(process.env.HUMAN_REVIEW_CLOSE_GRACE_MS || 5000);
+/** A session no tab ever connected to (the browser never opened) is dropped after this long. */
+const NEVER_OPENED_MS = Number(process.env.HUMAN_REVIEW_NEVER_OPENED_MS || 60 * 1000);
 /** A poll with no review open waits this long for one before giving up. */
 const NO_REVIEW_GRACE_MS = Number(process.env.HUMAN_REVIEW_NO_REVIEW_GRACE_MS || 10000);
 /** Edit text is capped so one pasted novel cannot bloat the state file; the cut is marked. */
@@ -749,6 +751,8 @@ export function createServer() {
           visited: new Set([page.key]),
           clients: new Set(),
           lastSeen: Date.now(),
+          createdAt: Date.now(),
+          everConnected: false,
           leftover,
           awayTimer: null,
         });
@@ -1170,6 +1174,7 @@ export function createServer() {
         // The tab that said it was leaving came back (a reload).
         clearTimeout(session.awayTimer);
         session.awayTimer = null;
+        session.everConnected = true;
         session.clients.add(res);
         seen(session);
         emit(session, "agent", { state: agentState(session.entryKey) });
@@ -1247,6 +1252,8 @@ export function createServer() {
     // laptop that never woke — so the review ends and any waiting agent is freed.
     for (const session of [...sessions.values()]) {
       if (session.clients.size === 0 && now - session.lastSeen > SESSION_TTL_MS) endSession(session, "window_closed");
+      // Opened by the CLI but no browser ever showed up: nothing to wait for.
+      else if (!session.everConnected && session.clients.size === 0 && now - (session.createdAt || 0) > NEVER_OPENED_MS) endSession(session, "window_closed");
     }
 
     // Stop watching files no remaining session can see.

--- a/src/server.js
+++ b/src/server.js
@@ -39,6 +39,18 @@ const WATCH_INTERVAL_MS = 400;
 const IDLE_SHUTDOWN_MS = Number(process.env.HUMAN_REVIEW_IDLE_MS || 45 * 60 * 1000);
 /** A window with no live connection this long is treated as closed for good. */
 const SESSION_TTL_MS = 30 * 60 * 1000;
+/** After a tab says it is going away, how long a reload has to come back. */
+const CLOSE_GRACE_MS = Number(process.env.HUMAN_REVIEW_CLOSE_GRACE_MS || 5000);
+/** A poll with no review open waits this long for one before giving up. */
+const NO_REVIEW_GRACE_MS = Number(process.env.HUMAN_REVIEW_NO_REVIEW_GRACE_MS || 10000);
+/** Edit text is capped so one pasted novel cannot bloat the state file; the cut is marked. */
+const EDIT_TEXT_CAP = 200000;
+const TRUNCATED_MARK = " …[truncated by human-review]";
+
+const SUPERSEDED = {
+  status: "superseded",
+  next_step: "A newer poll for this target took over the wait. Stop here and do not run the poll command again from this task.",
+};
 const MAX_LOCAL_REDIRECTS = 5;
 /** Generous enough for a dev server's cold compile, but a wedged one can't hang us forever. */
 const LOCAL_FETCH_TIMEOUT_MS = 30000;
@@ -158,8 +170,15 @@ export function createServer() {
   const pollers = new Map(); // entryKey -> Set<{ res, timer }>
   /** Pending batches awaiting --ack; mirrored to the store so they survive restarts. */
   const batches = new Map(
-    Object.entries(store.allBatches()).map(([key, record]) => [key, { batch: record.batch, cleanup: record.cleanup, delivered: false }])
+    Object.entries(store.allBatches()).map(([key, record]) => [
+      key,
+      { batch: record.batch, cleanup: record.cleanup, delivered: !!record.delivered, priorCleanup: record.priorCleanup || null },
+    ])
   );
+  /** Unguessable path segment for the artifact route, which the iframe cannot send a header to. */
+  const viewToken = crypto.randomBytes(8).toString("hex");
+  /** The localhost page most recently served, for proxying its app's own requests. */
+  let lastUrlPageKey = null;
   const watched = new Map(); // key -> { file }
   const lastWritten = new Map(); // key -> content hash human-review itself wrote
 
@@ -194,6 +213,9 @@ export function createServer() {
   function agentState(entryKey) {
     const pending = batches.get(entryKey);
     if (pending && pending.delivered) return "working";
+    // Sent while the agent was still applying the previous batch: it ships
+    // with the agent's next poll, so nobody needs to do anything.
+    if (pending && pending.priorCleanup) return "queued";
     const set = pollers.get(entryKey);
     if (set && set.size) return "listening";
     return pending ? "stranded" : "idle";
@@ -202,6 +224,57 @@ export function createServer() {
   function broadcastAgent(entryKey) {
     const state = agentState(entryKey);
     for (const session of sessionsForEntry(entryKey)) emit(session, "agent", { state });
+  }
+
+  /** Unsent feedback on every page reachable from this entry target. */
+  function unsentCounts(entryKey) {
+    const keys = new Set([entryKey]);
+    for (const session of sessions.values()) {
+      if (session.entryKey !== entryKey) continue;
+      for (const k of session.visited) keys.add(k);
+    }
+    let comments = 0;
+    let edits = 0;
+    for (const k of keys) {
+      const page = store.page(k);
+      if (!page) continue;
+      comments += page.comments.length;
+      edits += page.edits.length;
+    }
+    return { comments, edits };
+  }
+
+  const CLOSE_REASONS = {
+    ended: "The user ended this review from the browser.",
+    window_closed: "The user closed the review tab without sending.",
+    no_review_open: "No review is open for this target in the browser.",
+  };
+
+  function closedPayload(entryKey, reason) {
+    const unsent = unsentCounts(entryKey);
+    const left = unsent.comments + unsent.edits;
+    return {
+      status: "closed",
+      reason,
+      unsent,
+      next_step:
+        `${CLOSE_REASONS[reason] || CLOSE_REASONS.ended} Stop waiting — do not run the poll command again. ` +
+        (left
+          ? `${left} unsent ${left === 1 ? "item was" : "items were"} left behind; they are kept and the user can restore or discard them the next time this target is reviewed. Tell the user in one line, then stop.`
+          : "Nothing was left unsent. Tell the user the review closed, then stop."),
+    };
+  }
+
+  /** Hand every waiting poll for a target its final answer. */
+  function releasePollers(entryKey, payload) {
+    const set = pollers.get(entryKey);
+    if (!set) return;
+    for (const poller of [...set]) {
+      clearInterval(poller.timer);
+      clearTimeout(poller.graceTimer);
+      set.delete(poller);
+      poller.res.end(JSON.stringify(payload));
+    }
   }
 
   // ------------------------------------------------------------- file watch
@@ -223,7 +296,9 @@ export function createServer() {
       // Our own autosave must never bounce back as a reload.
       if (lastWritten.get(key) === current) return;
       lastWritten.set(key, current);
-      store.setPristine(key, html);
+      // Rows on a Markdown or self-rendering page are unsent feedback, not
+      // something this write already contains; keep them.
+      store.setPristine(key, html, { keepEdits: isMarkdown(page.file) || !!store.page(key)?.dynamic });
       for (const session of sessionsForKey(key)) emit(session, "reload", { key });
     });
   }
@@ -251,33 +326,49 @@ export function createServer() {
     return true;
   }
 
-  /** Every page you left feedback on ships in one batch, grouped by target. */
-  function collectPages(session) {
+  /**
+   * Every page you left feedback on ships in one batch, grouped by target.
+   * `already` is the cleanup of a batch the agent has but has not acked yet:
+   * anything it covers is in the agent's hands already and must not ship twice.
+   */
+  function collectPages(session, already = []) {
     const out = [];
     for (const key of session.visited) {
       const page = store.page(key);
       if (!page) continue;
-      if (!page.comments.length && !page.edits.length) continue;
+      const covered = already.filter((entry) => entry.key === key);
+      const coveredIds = new Set(covered.flatMap((entry) => entry.ids));
+      const coveredUntil = covered.reduce((max, entry) => Math.max(max, entry.sentAt || 0), 0);
+      const comments = page.comments.filter((c) => !coveredIds.has(c.id));
+      const edits = page.edits.filter((e) => (e.updatedAt || e.at || 0) >= coveredUntil);
+      if (!comments.length && !edits.length) continue;
+      const markdown = page.kind !== "url" && isMarkdown(page.file);
       out.push({
         key,
         kind: page.kind === "url" ? "url" : "file",
         file: page.kind === "url" ? page.url : page.file,
         url: page.kind === "url" ? page.url : undefined,
-        comments: page.comments.map((c) => ({
+        markdown,
+        // Direct edits to a plain HTML file are autosaved into it as they
+        // happen; everywhere else they exist only in this batch.
+        edits_saved: page.kind !== "url" && !markdown && !page.dynamic,
+        comments: comments.map((c) => ({
           id: c.id,
           kind: c.kind,
           quote: c.quote,
           anchor: c.anchor,
           feedback: c.feedback,
         })),
-        edits: page.edits.map((e) => ({
+        edits: edits.map((e) => ({
           label: e.label,
           kind: e.kind,
           before: e.before,
           after: e.after,
           ...(e.before_html !== undefined && e.before_html !== e.before ? { before_html: e.before_html } : {}),
           ...(e.after_html !== undefined && e.after_html !== e.after ? { after_html: e.after_html } : {}),
+          ...(e.kind === "moved" ? { moved_after: e.moved_after || "", moved_before: e.moved_before || "" } : {}),
           ...(Array.isArray(e.staged_assets) && e.staged_assets.length ? { staged_assets: e.staged_assets } : {}),
+          ...(e.truncated ? { truncated: true } : {}),
         })),
       });
     }
@@ -299,14 +390,30 @@ export function createServer() {
     const session = sessions.get(sessionId);
     if (!session) return { error: "unknown session" };
 
-    const pages = collectPages(session);
-    if (!pages.length && !note) return { error: "nothing to send" };
+    // A batch the agent took but has not acked is in its hands: the new Send
+    // carries only what came after it, and the old cleanup rides along so the
+    // agent's next --ack clears both.
+    const previous = batches.get(session.entryKey);
+    const inFlight = previous && previous.delivered ? previous : null;
+    const already = inFlight ? [...(inFlight.priorCleanup || []), ...inFlight.cleanup] : previous ? previous.priorCleanup || [] : [];
+    const pages = collectPages(session, already);
+    if (!pages.length && !note) return { error: inFlight ? "nothing new since the batch the agent is working on" : "nothing to send" };
 
-    const hasMarkdown = pages.some((p) => p.kind === "file" && isMarkdown(p.file));
+    const hasMarkdown = pages.some((p) => p.markdown);
     const hasUrl = pages.some((p) => p.kind === "url");
+    const hasSaved = pages.some((p) => p.edits_saved && p.edits.length);
+    const hasTruncated = pages.some((p) => p.edits.some((e) => e.truncated));
     const batch = {
       status: "feedback",
-      pages: pages.map(({ kind, file, url, comments, edits }) => ({ kind, file, ...(url ? { url } : {}), comments, edits })),
+      pages: pages.map(({ kind, file, url, markdown, edits_saved, comments, edits }) => ({
+        kind,
+        file,
+        ...(url ? { url } : {}),
+        ...(markdown ? { markdown: true } : {}),
+        edits_saved,
+        comments,
+        edits,
+      })),
       overall_note: note || "",
       sent_at: new Date().toISOString(),
       next_step:
@@ -314,6 +421,13 @@ export function createServer() {
         "changes the human already made: `after` is their exact new wording, so carry it across verbatim, and " +
         "never revert it. When an edit carries `after_html`, the human changed formatting (bold, italic, links) — " +
         "use the HTML version, translated into the source's own syntax. " +
+        (hasSaved
+          ? "Pages with `edits_saved: true` already contain those edits on disk: re-read the file before touching it and " +
+            "make targeted changes only — never regenerate it from an older copy, or their work disappears. "
+          : "") +
+        (hasTruncated
+          ? "An edit marked `truncated` had its text cut at " + EDIT_TEXT_CAP + " characters; read the block from the page itself. "
+          : "") +
         (hasMarkdown
           ? "Markdown pages were reviewed rendered, so quotes and `after` wording use the rendered text — apply " +
             "the change to the Markdown source, keeping its formatting syntax. "
@@ -331,6 +445,7 @@ export function createServer() {
     const record = {
       batch,
       delivered: false,
+      priorCleanup: already.length ? already : null,
       cleanup: pages.map((p) => ({
         key: p.key,
         ids: p.comments.map((c) => c.id),
@@ -339,22 +454,16 @@ export function createServer() {
       })),
     };
     batches.set(session.entryKey, record);
-    store.setBatch(session.entryKey, record);
     record.delivered = deliver(session.entryKey, batch);
+    store.setBatch(session.entryKey, record);
     broadcastAgent(session.entryKey);
     return { ok: true };
   }
 
-  function ack(entryKey) {
-    const pending = batches.get(entryKey);
-    // Only a delivered batch can be acknowledged. An agent whose previous poll
-    // timed out re-runs `poll --ack`; if feedback arrived in between, that ack
-    // refers to an older batch and must not destroy the one it never saw.
-    if (!pending || !pending.delivered) return false;
-    batches.delete(entryKey);
-    store.clearBatch(entryKey);
+  /** Forget the feedback a batch carried, now that the agent has applied it. */
+  function applyCleanup(entryKey, cleanup) {
     const stagedRoot = path.join(stateDir(), "pasted");
-    for (const file of pending.cleanup.flatMap((entry) => entry.staged || [])) {
+    for (const file of cleanup.flatMap((entry) => entry.staged || [])) {
       const resolved = path.resolve(file);
       const relative = path.relative(stagedRoot, resolved);
       if (relative.startsWith("..") || path.isAbsolute(relative)) continue;
@@ -363,47 +472,71 @@ export function createServer() {
         fs.rmdirSync(path.dirname(resolved));
       } catch {}
     }
-    for (const { key, ids, sentAt } of pending.cleanup) store.clearSent(key, ids, sentAt);
+    for (const { key, ids, sentAt } of cleanup) store.clearSent(key, ids, sentAt);
     for (const session of sessionsForEntry(entryKey)) emit(session, "refresh", {});
     // File targets reload through fs.watch. URL targets have no source file to
     // watch, so acknowledgement is the signal to fetch the rebuilt route.
-    for (const { key } of pending.cleanup) {
+    for (const { key } of cleanup) {
       if (store.page(key)?.kind === "url") {
         for (const session of sessionsForKey(key)) emit(session, "reload", { key });
       }
     }
+  }
+
+  function ack(entryKey) {
+    const pending = batches.get(entryKey) || store.batchFromDisk(entryKey);
+    if (!pending) return false;
+    if (!pending.delivered) {
+      // The agent is acking the batch it had, which a newer Send has since
+      // queued behind. Clear that one; the new batch is delivered untouched.
+      if (!pending.priorCleanup) return false;
+      const prior = pending.priorCleanup;
+      pending.priorCleanup = null;
+      batches.set(entryKey, pending);
+      store.setBatch(entryKey, pending);
+      applyCleanup(entryKey, prior);
+      broadcastAgent(entryKey);
+      return true;
+    }
+    batches.delete(entryKey);
+    store.clearBatch(entryKey);
+    applyCleanup(entryKey, [...(pending.priorCleanup || []), ...pending.cleanup]);
     broadcastAgent(entryKey);
     return true;
   }
 
   /**
-   * A deliberate stop, not a tab close: the browser forgets the session and
-   * any waiting agent is released with a clear "stop polling" answer instead
-   * of being left to burn its timeout. Unsent feedback stays in the store.
+   * The review is over — the user hit End review, closed the tab, or the tab
+   * never came back. The browser forgets the session and any waiting agent is
+   * released with a clear "stop" answer instead of waiting forever. Unsent
+   * feedback stays in the store; the next open offers to restore or discard it.
    */
-  function endSession(session) {
+  function endSession(session, reason = "ended") {
+    clearTimeout(session.awayTimer);
     sessions.delete(session.id);
     for (const res of session.clients) {
-      res.write(`event: ended\ndata: {}\n\n`);
+      res.write(`event: ended\ndata: ${JSON.stringify({ reason })}\n\n`);
       res.end();
     }
     session.clients.clear();
     // Another window on the same target keeps its agent connection alive.
     if (sessionsForEntry(session.entryKey).length > 0) return;
-    const set = pollers.get(session.entryKey);
-    if (!set) return;
-    for (const poller of [...set]) {
-      clearInterval(poller.timer);
-      set.delete(poller);
-      poller.res.end(
-        JSON.stringify({
-          status: "closed",
-          next_step:
-            "The user ended this review session. Stop polling — do not run the poll command again. " +
-            "Any unsent feedback is kept and will ship the next time this target is reviewed.",
-        })
-      );
-    }
+    // A batch the user sent must reach the agent before the close does; the
+    // poll route returns it first, and the closed answer follows on the next poll.
+    if (batches.get(session.entryKey)) return;
+    releasePollers(session.entryKey, closedPayload(session.entryKey, reason));
+  }
+
+  /**
+   * The tab said it is unloading. A reload reconnects within moments; a real
+   * close never does, and then the review ends and the waiting agent is freed.
+   */
+  function scheduleAway(session) {
+    clearTimeout(session.awayTimer);
+    session.awayTimer = setTimeout(() => {
+      if (!sessions.has(session.id) || session.clients.size > 0) return;
+      endSession(session, "window_closed");
+    }, CLOSE_GRACE_MS);
   }
 
   // ----------------------------------------------------------------- routes
@@ -501,6 +634,54 @@ export function createServer() {
     };
   }
 
+  const STATIC = {
+    "/chrome.css": ["chrome.css", null],
+    "/chrome.js": ["chrome-client.js", CORS],
+    "/chrome-session.js": ["chrome-session.js", CORS],
+    "/sdk.js": ["sdk.js", CORS],
+    "/editing.js": ["editing.js", CORS],
+    "/anchor-text.js": ["anchor-text.js", CORS],
+    "/frame-policy.js": ["frame-policy.js", CORS],
+    "/click-target.js": ["click-target.js", CORS],
+    "/serialize.js": ["serialize.js", CORS],
+  };
+
+  /**
+   * A localhost app under review keeps fetching from its own origin: API
+   * calls, route prefetches, chunk loads, images from `srcset`. Inside the
+   * review those land here instead, so anything that is not ours is passed
+   * through to the app, unchanged in both directions.
+   */
+  function proxyToApp(req, res, target) {
+    const headers = { ...req.headers, host: target.host };
+    delete headers.cookie;
+    const upstream = http.request(target, { method: req.method, headers }, (up) => {
+      const out = { ...up.headers };
+      // The response now lives on the review origin; app cookies must not
+      // land here, and frame-blocking headers would blank the iframe.
+      delete out["set-cookie"];
+      delete out["x-frame-options"];
+      delete out["content-security-policy"];
+      res.writeHead(up.statusCode || 502, out);
+      up.pipe(res);
+    });
+    upstream.on("error", (err) => {
+      if (!res.headersSent) res.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
+      res.end(`Could not reach ${target.href}: ${err.message}`);
+    });
+    req.pipe(upstream);
+  }
+
+  /** The localhost page whose app a stray request belongs to, if any. */
+  function appPageFor(req) {
+    const cookie = String(req.headers.cookie || "");
+    const match = cookie.match(/(?:^|;\s*)__hr_page=([a-f0-9]+)/);
+    const fromCookie = match ? store.page(match[1]) : null;
+    if (fromCookie && fromCookie.kind === "url") return fromCookie;
+    const last = lastUrlPageKey ? store.page(lastUrlPageKey) : null;
+    return last && last.kind === "url" ? last : null;
+  }
+
   const server = http.createServer(async (req, res) => {
     touch();
     const url = new URL(req.url, "http://127.0.0.1");
@@ -519,6 +700,14 @@ export function createServer() {
 
       if (route === "/health") return json(res, 200, { ok: true, pid: process.pid, protocol: SERVER_PROTOCOL });
 
+      // Our own callers always send the token; an app under review never
+      // does. Anything else it asks for is its own, and goes to the app.
+      const ours = STATIC[route] || route.startsWith("/artifact/") || route.startsWith("/s/") || route.startsWith("/events/");
+      if (!ours && !req.headers["x-human-review-token"]) {
+        const appPage = appPageFor(req);
+        if (appPage) return proxyToApp(req, res, new URL(`${route}${url.search}`, appPage.url));
+      }
+
       // Every API route needs the per-run token; static assets and the
       // unguessable /s/<id> chrome page do not.
       // Header only — a token in a query string would leak into logs and
@@ -531,15 +720,7 @@ export function createServer() {
       }
 
       // --- static chrome assets
-      if (route === "/chrome.css") return serveFile(res, path.join(here, "chrome.css"));
-      if (route === "/chrome.js") return serveFile(res, path.join(here, "chrome-client.js"), CORS);
-      if (route === "/chrome-session.js") return serveFile(res, path.join(here, "chrome-session.js"), CORS);
-      if (route === "/sdk.js") return serveFile(res, path.join(here, "sdk.js"), CORS);
-      if (route === "/editing.js") return serveFile(res, path.join(here, "editing.js"), CORS);
-      if (route === "/anchor-text.js") return serveFile(res, path.join(here, "anchor-text.js"), CORS);
-      if (route === "/frame-policy.js") return serveFile(res, path.join(here, "frame-policy.js"), CORS);
-      if (route === "/click-target.js") return serveFile(res, path.join(here, "click-target.js"), CORS);
-      if (route === "/serialize.js") return serveFile(res, path.join(here, "serialize.js"), CORS);
+      if (STATIC[route]) return serveFile(res, path.join(here, STATIC[route][0]), STATIC[route][1] || undefined);
 
       // --- open a browser session for a file or localhost URL
       if (route === "/api/session" && req.method === "POST") {
@@ -558,8 +739,23 @@ export function createServer() {
         }
         watchPage(page.key);
         const id = uid("s");
-        sessions.set(id, { id, entryKey: page.key, activeKey: page.key, visited: new Set([page.key]), clients: new Set(), lastSeen: Date.now() });
-        return json(res, 200, { sessionId: id, key: page.key, path: `/s/${id}` });
+        // Feedback already on the page is from an earlier review that ended
+        // without a Send; the browser offers to restore or discard it.
+        const leftover = { comments: page.comments.length, edits: page.edits.length };
+        sessions.set(id, {
+          id,
+          entryKey: page.key,
+          activeKey: page.key,
+          visited: new Set([page.key]),
+          clients: new Set(),
+          lastSeen: Date.now(),
+          leftover,
+          awayTimer: null,
+        });
+        // A poll that was about to give up for lack of a review has one now.
+        for (const poller of pollers.get(page.key) || []) clearTimeout(poller.graceTimer);
+        broadcastAgent(page.key);
+        return json(res, 200, { sessionId: id, key: page.key, path: `/s/${id}`, artifactToken: viewToken, leftover });
       }
 
       // --- the chrome page
@@ -575,13 +771,15 @@ export function createServer() {
         return res.end(shell.replace("__SESSION_ID__", id).replace("__TOKEN__", token));
       }
 
-      // --- the reviewed page itself, plus sibling assets for file targets
+      // --- the reviewed page itself, plus sibling assets for file targets.
+      // The iframe cannot send the token header, so the URL carries a secret
+      // of its own: the page key alone is derived from the file path, which a
+      // dev server on another port could guess.
       if (route.startsWith("/artifact/")) {
-        const rest = route.slice("/artifact/".length);
-        const slash = rest.indexOf("/");
-        const key = slash === -1 ? rest : rest.slice(0, slash);
-        const asset = slash === -1 ? "" : rest.slice(slash + 1);
-        const page = store.page(key);
+        const parts = route.slice("/artifact/".length).split("/");
+        const [vt, key = ""] = parts;
+        const asset = parts.slice(2).join("/");
+        const page = vt === viewToken ? store.page(key) : null;
         if (!page) {
           res.writeHead(404, { "content-type": "text/plain" });
           return res.end("Unknown page");
@@ -611,7 +809,13 @@ export function createServer() {
             // Markdown reviews render on the fly; the source file stays untouched.
             if (isMarkdown(page.file)) html = renderMarkdownPage(html, page.file);
           }
-          res.writeHead(200, { "content-type": MIME[".html"], "cache-control": "no-store" });
+          const headers = { "content-type": MIME[".html"], "cache-control": "no-store" };
+          if (page.kind === "url") {
+            // Names the app that later same-origin requests belong to.
+            lastUrlPageKey = key;
+            headers["set-cookie"] = `__hr_page=${key}; Path=/; SameSite=Lax`;
+          }
+          res.writeHead(200, headers);
           return res.end(injectSdk(html, key, sdkOptions));
         }
         if (page.kind === "url") {
@@ -624,8 +828,7 @@ export function createServer() {
             }
             return serveFile(res, path.join(stateDir(), "pasted", key, name));
           }
-          res.writeHead(404, { "content-type": "text/plain" });
-          return res.end("Localhost assets load from the reviewed development server.");
+          return proxyToApp(req, res, new URL(`${asset}${url.search}`, page.url));
         }
         const target = resolveAsset(page.file, asset.split("?")[0]);
         if (!target) {
@@ -638,28 +841,16 @@ export function createServer() {
       // --- agent status probe: is feedback waiting? is anyone listening?
       if (route === "/api/status" && req.method === "GET") {
         const entryKey = targetKey(url.searchParams.get("target") || url.searchParams.get("file") || "");
-        const pending = batches.get(entryKey);
+        const pending = batches.get(entryKey) || store.batchFromDisk(entryKey);
         const listening = (pollers.get(entryKey) || new Set()).size > 0;
-        // Unsent feedback lives on every page reachable from this entry.
-        const keys = new Set([entryKey]);
-        for (const session of sessions.values()) {
-          if (session.entryKey !== entryKey) continue;
-          for (const k of session.visited) keys.add(k);
-        }
-        let comments = 0;
-        let edits = 0;
-        for (const k of keys) {
-          const page = store.page(k);
-          if (!page) continue;
-          comments += page.comments.length;
-          edits += page.edits.length;
-        }
+        const reviewOpen = sessionsForEntry(entryKey).length > 0;
         return json(res, 200, {
           status: pending ? "feedback-waiting" : "idle",
           feedback_waiting: !!pending,
           agent_listening: listening,
+          review_open: reviewOpen,
           server_running: true,
-          unsent: { comments, edits },
+          unsent: unsentCounts(entryKey),
         });
       }
 
@@ -720,15 +911,40 @@ export function createServer() {
           const body = await readBody(req);
           const feedback = String(body.feedback || "").trim();
           if (!feedback) return json(res, 400, { error: "empty feedback" });
+          const carrying = [...batches.entries()].find(([, record]) =>
+            [...(record.priorCleanup || []), ...record.cleanup].some((entry) => entry.key === key && entry.ids.includes(tail))
+          );
+          if (carrying && !carrying[1].delivered && !(carrying[1].priorCleanup || []).some((e) => e.ids.includes(tail))) {
+            // Sent but not yet taken: the waiting batch can still be reworded in place.
+            if (!store.updateComment(key, tail, feedback)) return json(res, 404, { error: "unknown comment" });
+            const [entryKey, record] = carrying;
+            for (const page of record.batch.pages) {
+              for (const comment of page.comments) if (comment.id === tail) comment.feedback = feedback;
+            }
+            store.setBatch(entryKey, record);
+            return json(res, 200, { delivery: "updated-pending", page: pageState(key) });
+          }
+          if (carrying) {
+            // The agent already has the old wording. Retire that id so the
+            // ack does not clear the rewrite; it ships with the next Send.
+            if (!store.updateComment(key, tail, feedback, { newId: uid("c") })) return json(res, 404, { error: "unknown comment" });
+            return json(res, 200, { delivery: "resend", page: pageState(key) });
+          }
           if (!store.updateComment(key, tail, feedback)) return json(res, 404, { error: "unknown comment" });
-          return json(res, 200, { page: pageState(key) });
+          return json(res, 200, { delivery: "unsent", page: pageState(key) });
         }
 
         if (action === "edit" && req.method === "POST") {
           const body = await readBody(req);
           const label = String(body.label || "Document");
           const kind = body.kind === "deleted" ? "deleted" : body.kind === "moved" ? "moved" : "edited";
-          const cap = (s) => (typeof s === "string" ? s.slice(0, 4000) : undefined);
+          let truncated = false;
+          const cap = (s) => {
+            if (typeof s !== "string") return undefined;
+            if (s.length <= EDIT_TEXT_CAP) return s;
+            truncated = true;
+            return `${s.slice(0, EDIT_TEXT_CAP)}${TRUNCATED_MARK}`;
+          };
           const stagedRoot = path.join(stateDir(), "pasted", key);
           const stagedAssets = Array.isArray(body.staged_assets)
             ? body.staged_assets
@@ -747,11 +963,35 @@ export function createServer() {
                 })
                 .map(({ path: assetPath, preview_src }) => ({ path: assetPath, preview_src }))
             : [];
+          const fields = [cap(body.before), cap(body.after), cap(body.before_html), cap(body.after_html)];
           const extra = {
             ...(kind === "moved" ? { moved_after: cap(body.moved_after) || "", moved_before: cap(body.moved_before) || "" } : {}),
             ...(stagedAssets.length ? { staged_assets: stagedAssets } : {}),
+            ...(truncated ? { truncated: true } : {}),
           };
-          store.addEdit(key, label, kind, cap(body.before), cap(body.after), cap(body.before_html), cap(body.after_html), extra);
+          store.addEdit(key, label, kind, ...fields, extra);
+          return json(res, 200, { page: pageState(key) });
+        }
+
+        // Undo of a delete or move: the block is back where it was.
+        if (action === "edit" && req.method === "DELETE") {
+          const body = await readBody(req);
+          const kind = body.kind === "deleted" ? "deleted" : body.kind === "moved" ? "moved" : "edited";
+          store.removeEdit(key, String(body.label || ""), kind);
+          return json(res, 200, { page: pageState(key) });
+        }
+
+        // The SDK found the page renders itself; its edits are feedback only.
+        if (action === "mode" && req.method === "POST") {
+          const body = await readBody(req);
+          store.setDynamic(key, !!body.dynamic);
+          return json(res, 200, { page: pageState(key) });
+        }
+
+        // Leftover feedback from an earlier review the user chose not to keep.
+        if (action === "discard" && req.method === "POST") {
+          store.discardFeedback(key);
+          for (const session of sessionsForKey(key)) emit(session, "refresh", {});
           return json(res, 200, { page: pageState(key) });
         }
 
@@ -781,7 +1021,7 @@ export function createServer() {
           const saved = path.join(dir, name);
           fs.writeFileSync(saved, bytes);
           return json(res, 200, {
-            src: staged ? `/artifact/${key}/__human_review_paste__/${name}` : `assets/${name}`,
+            src: staged ? `/artifact/${viewToken}/${key}/__human_review_paste__/${name}` : `assets/${name}`,
             ...(staged ? { stagedId: name } : {}),
           });
         }
@@ -841,7 +1081,16 @@ export function createServer() {
       if (endMatch && req.method === "POST") {
         const session = sessions.get(endMatch[1]);
         if (!session) return json(res, 404, { error: "unknown session" });
-        endSession(session);
+        endSession(session, "ended");
+        return json(res, 200, { ok: true });
+      }
+
+      // --- the tab is unloading: a reload comes right back, a close never does
+      const awayMatch = route.match(/^\/api\/session\/(\w+)\/away$/);
+      if (awayMatch && req.method === "POST") {
+        const session = sessions.get(awayMatch[1]);
+        if (!session) return json(res, 404, { error: "unknown session" });
+        scheduleAway(session);
         return json(res, 200, { ok: true });
       }
 
@@ -855,6 +1104,8 @@ export function createServer() {
           key: session.activeKey,
           page: pageState(session.activeKey, session),
           others: otherPages(session),
+          artifactToken: viewToken,
+          leftover: session.leftover || { comments: 0, edits: 0 },
         });
       }
 
@@ -916,6 +1167,9 @@ export function createServer() {
           connection: "keep-alive",
         });
         res.write(": open\n\n");
+        // The tab that said it was leaving came back (a reload).
+        clearTimeout(session.awayTimer);
+        session.awayTimer = null;
         session.clients.add(res);
         seen(session);
         emit(session, "agent", { state: agentState(session.entryKey) });
@@ -934,25 +1188,45 @@ export function createServer() {
         const entryKey = targetKey(target);
         if (url.searchParams.get("ack") === "1") ack(entryKey);
 
-        const pending = batches.get(entryKey);
+        // Feedback first, always: a Send must reach the agent even if the tab
+        // closed right after it, and even if another server wrote it.
+        const pending = batches.get(entryKey) || store.batchFromDisk(entryKey);
         if (pending) {
+          batches.set(entryKey, pending);
           pending.delivered = true;
+          store.markDelivered(entryKey);
           broadcastAgent(entryKey);
           return json(res, 200, pending.batch);
         }
 
         res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
         res.write(" ");
+        // One waiter per target: an older poll left behind by an earlier turn
+        // would otherwise take the next batch too, and apply it twice.
+        releasePollers(entryKey, SUPERSEDED);
         const set = pollers.get(entryKey) || new Set();
         pollers.set(entryKey, set);
         const poller = {
           res,
           timer: setInterval(() => res.write(" "), POLL_HEARTBEAT_MS),
+          graceTimer: null,
         };
+        // No review open for this target: give the browser a moment to open
+        // one (an `open` that is still launching, a tab re-registering after a
+        // server restart), then release the agent rather than wait forever.
+        if (sessionsForEntry(entryKey).length === 0) {
+          poller.graceTimer = setTimeout(() => {
+            if (!set.has(poller) || sessionsForEntry(entryKey).length > 0) return;
+            clearInterval(poller.timer);
+            set.delete(poller);
+            poller.res.end(JSON.stringify(closedPayload(entryKey, "no_review_open")));
+          }, NO_REVIEW_GRACE_MS);
+        }
         set.add(poller);
         broadcastAgent(entryKey);
         req.on("close", () => {
           clearInterval(poller.timer);
+          clearTimeout(poller.graceTimer);
           set.delete(poller);
           broadcastAgent(entryKey);
         });
@@ -969,9 +1243,10 @@ export function createServer() {
   const sweep = setInterval(() => {
     const now = Date.now();
 
-    // A window with no SSE client for a while is closed; forget its session.
-    for (const [id, session] of sessions) {
-      if (session.clients.size === 0 && now - session.lastSeen > SESSION_TTL_MS) sessions.delete(id);
+    // A window with no SSE client for a while is gone for good — a crash, a
+    // laptop that never woke — so the review ends and any waiting agent is freed.
+    for (const session of [...sessions.values()]) {
+      if (session.clients.size === 0 && now - session.lastSeen > SESSION_TTL_MS) endSession(session, "window_closed");
     }
 
     // Stop watching files no remaining session can see.
@@ -1001,7 +1276,120 @@ export function createServer() {
   return { server, store, token, dispose };
 }
 
-export function start(port = 0) {
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function probeHealth(port) {
+  return new Promise((resolve) => {
+    const req = http.get({ host: "127.0.0.1", port, path: "/health", timeout: 1200 }, (res) => {
+      let raw = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        raw += chunk;
+      });
+      res.on("end", () => {
+        try {
+          resolve(res.statusCode === 200 ? JSON.parse(raw) : null);
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+    req.on("error", () => resolve(null));
+    req.on("timeout", () => req.destroy());
+  });
+}
+
+const pidAlive = (pid) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === "EPERM";
+  }
+};
+
+const lockPath = () => path.join(stateDir(), "server.lock");
+let holdsLock = false;
+
+/**
+ * Exactly one review server per state directory. Two CLIs racing to start
+ * one would otherwise each spawn a server, and the browser tab would post
+ * to one while the agent polls the other, with feedback stranded between.
+ * A live server on the current protocol wins; an older one is asked to leave.
+ */
+async function claimServerSlot() {
+  ensureStateDir();
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      fs.writeFileSync(lockPath(), String(process.pid), { flag: "wx" });
+      holdsLock = true;
+      break;
+    } catch {
+      let holder = 0;
+      try {
+        holder = Number(fs.readFileSync(lockPath(), "utf8"));
+      } catch {}
+      if (holder === process.pid) {
+        holdsLock = true;
+        break;
+      }
+      if (holder && pidAlive(holder)) {
+        // Another process is starting or running; let it, unless it is
+        // stale and never got as far as announcing itself.
+        await sleep(300);
+        const saved = readServerRecord();
+        if (saved && saved.pid === holder) return { proceed: false };
+        if (attempt < 2) continue;
+        return { proceed: false };
+      }
+      try {
+        fs.unlinkSync(lockPath());
+      } catch {}
+    }
+  }
+  if (!holdsLock) return { proceed: false };
+
+  const saved = readServerRecord();
+  if (saved && saved.pid && saved.pid !== process.pid) {
+    const health = await probeHealth(saved.port);
+    if (health && health.pid === saved.pid) {
+      if (saved.protocol === SERVER_PROTOCOL) return { proceed: false };
+      // An older server: it answered /health with its own pid, so this is
+      // ours to replace. Waiting polls reconnect to the new one on their own.
+      try {
+        process.kill(saved.pid, "SIGTERM");
+      } catch {}
+      for (let i = 0; i < 30 && (await probeHealth(saved.port)); i += 1) await sleep(100);
+    }
+  }
+  return { proceed: true };
+}
+
+function releaseServerSlot() {
+  if (!holdsLock) return;
+  holdsLock = false;
+  try {
+    if (Number(fs.readFileSync(lockPath(), "utf8")) === process.pid) fs.unlinkSync(lockPath());
+  } catch {}
+}
+
+function readServerRecord() {
+  try {
+    return JSON.parse(fs.readFileSync(serverPath(), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+process.on("exit", releaseServerSlot);
+
+export async function start(port = 0) {
+  const claim = await claimServerSlot();
+  if (!claim.proceed) {
+    const err = new Error("a human-review server is already running for this state directory");
+    err.code = "EALREADY";
+    throw err;
+  }
   const { server, store, token, dispose } = createServer();
   return new Promise((resolve, reject) => {
     // Without this, a busy HUMAN_REVIEW_PORT dies as an uncaught exception.

--- a/src/setup.js
+++ b/src/setup.js
@@ -64,20 +64,20 @@ const CODEX_BLOCK = `
 After writing an HTML or Markdown file the user will read, open it for them with
 \`npx -y human-review <file.html>\`. For a locally running web page, open the real
 route with \`npx -y human-review http://localhost:3000/path\` instead of recreating
-it as a static file. Then start
-\`npx -y human-review poll <target>\` in the background and end the turn: it
+it as a static file. Then run
+\`npx -y human-review poll <target>\` in the foreground and stay on it: it
 blocks until the user hits Send, prints the \`{"status":"feedback"}\` batch,
-and exits, which wakes you. Do not add \`--timeout\` and do not poll on an
-interval. Apply the batch, then start the next background poll with \`--ack\`.
+and exits. Do not detach it or start it as a background session — nothing
+wakes you when a detached command finishes, so the user's Send would sit
+unread. Do not poll on an interval. If your shell tool enforces a maximum
+command duration, pass \`--timeout\` a little under that limit and run the
+same command again on \`{"status":"timeout"}\`. Apply the batch, then run
+the poll again with \`--ack\`.
 \`{"status":"closed"}\` means the review is over (ended, tab closed, or none
 open); do not poll again, and if its \`unsent\` counts are not zero, tell the user
 in one line. \`{"status":"superseded"}\` means a newer poll of yours owns the
-wait; stop this one silently.
-
-Only if your harness cannot wake you when a background command exits, keep the
-poll in the foreground (or wait on the process handle it returns) until it
-exits. \`npx -y human-review status <target>\` reports instantly whether
-feedback is already waiting, without blocking.
+wait; stop this one silently. \`npx -y human-review status <target>\` reports
+instantly whether feedback is already waiting, without blocking.
 
 The batch groups feedback by page under \`pages\`, so fix every page listed. Items
 under \`edits\` are changes the user already made: \`after\` is their exact wording,

--- a/src/setup.js
+++ b/src/setup.js
@@ -97,6 +97,39 @@ A page with \`edits_saved: true\` already has those edits on disk: re-read the
 file and make targeted changes only, never regenerate it from an older copy.
 `;
 
+const BLOCK_START = "<!-- human-review:start -->";
+const BLOCK_END = "<!-- human-review:end -->";
+/** The heading an older setup wrote, before the block carried markers. */
+const LEGACY_HEADING = "## Reviewing files and localhost pages with human-review";
+
+/**
+ * Put the current Codex block into AGENTS.md, replacing whatever an earlier
+ * setup left there. Instructions in this file used to be written once and
+ * never touched again, so projects set up months ago kept telling Codex to
+ * do things the tool no longer does. Marker comments make the block ours
+ * to rewrite; a project that mentions human-review in its own words is left
+ * alone.
+ */
+export function mergeAgentsBlock(existing, block) {
+  const marked = `${BLOCK_START}\n${block.trim()}\n${BLOCK_END}\n`;
+  if (!existing) return { text: marked, action: "created" };
+  const start = existing.indexOf(BLOCK_START);
+  const end = existing.indexOf(BLOCK_END, start === -1 ? 0 : start);
+  if (start !== -1 && end !== -1) {
+    const tail = existing.slice(end + BLOCK_END.length).replace(/^\n/, "");
+    const text = `${existing.slice(0, start)}${marked}${tail}`;
+    return { text, action: text === existing ? "current" : "updated" };
+  }
+  const head = existing.indexOf(LEGACY_HEADING);
+  if (head !== -1) {
+    const next = existing.indexOf("\n## ", head + LEGACY_HEADING.length);
+    const stop = next === -1 ? existing.length : next + 1;
+    return { text: `${existing.slice(0, head)}${marked}${existing.slice(stop)}`, action: "updated" };
+  }
+  if (existing.includes("human-review")) return { text: existing, action: "custom" };
+  return { text: `${existing.trimEnd()}\n\n${marked}`, action: "updated" };
+}
+
 export function installSkills(cwd, { global: isGlobal = false, home = os.homedir() } = {}) {
   const done = [];
   const cmd = invocation();
@@ -119,12 +152,12 @@ export function installSkills(cwd, { global: isGlobal = false, home = os.homedir
   if (!isGlobal) {
     const agents = path.join(cwd, "AGENTS.md");
     const existing = fs.existsSync(agents) ? fs.readFileSync(agents, "utf8") : "";
-    if (existing.includes("human-review")) {
-      done.push("AGENTS.md already mentions human-review — left it alone");
-    } else {
-      const block = CODEX_BLOCK.replaceAll("npx -y human-review", cmd);
-      fs.writeFileSync(agents, existing ? `${existing.trimEnd()}\n${block}` : block.trimStart());
-      done.push(`${existing ? "Updated" : "Created"} AGENTS.md   (Codex)`);
+    const { text, action } = mergeAgentsBlock(existing, CODEX_BLOCK.replaceAll("npx -y human-review", cmd));
+    if (action === "custom") done.push("AGENTS.md mentions human-review in its own words — left it alone");
+    else if (action === "current") done.push("AGENTS.md already current   (Codex)");
+    else {
+      fs.writeFileSync(agents, text);
+      done.push(`${action === "created" ? "Created" : "Updated"} AGENTS.md   (Codex)`);
     }
   }
 

--- a/src/setup.js
+++ b/src/setup.js
@@ -69,7 +69,10 @@ it as a static file. Then start
 blocks until the user hits Send, prints the \`{"status":"feedback"}\` batch,
 and exits, which wakes you. Do not add \`--timeout\` and do not poll on an
 interval. Apply the batch, then start the next background poll with \`--ack\`.
-\`{"status":"closed"}\` means the user ended the review; do not poll again.
+\`{"status":"closed"}\` means the review is over (ended, tab closed, or none
+open); do not poll again, and if its \`unsent\` counts are not zero, tell the user
+in one line. \`{"status":"superseded"}\` means a newer poll of yours owns the
+wait; stop this one silently.
 
 Only if your harness cannot wake you when a background command exits, keep the
 poll in the foreground (or wait on the process handle it returns) until it
@@ -85,6 +88,8 @@ Markdown source, keeping its syntax. There is no reply channel; the user sees
 your work when the page reloads. For a localhost page, direct edits and deletions
 arrive with \`kind: "url"\`; find and update the matching MDX, TSX, template, or
 component source. Never write the rendered HTTP response over project source.
+A page with \`edits_saved: true\` already has those edits on disk: re-read the
+file and make targeted changes only, never regenerate it from an older copy.
 `;
 
 export function installSkills(cwd, { global: isGlobal = false, home = os.homedir() } = {}) {

--- a/src/setup.js
+++ b/src/setup.js
@@ -11,22 +11,36 @@ const here = path.dirname(fileURLToPath(import.meta.url));
  * `npm link` puts `human-review` on PATH; otherwise fall back to npx, which only
  * resolves once the package is published.
  *
- * The probe has to discount its own npx run. `npx -y human-review setup --global`
- * puts this package on PATH for the duration of that one command, out of npm's
- * `_npx` cache, so a naive `which` succeeds and setup writes a bare
- * `human-review` into SKILL.md. That binary is gone the moment npx exits, and
- * every later agent invocation dies with "command not found".
+ * The probe has to discount its own runner. `npx -y human-review setup --global`
+ * puts this package on PATH for the length of that one command, and running
+ * setup inside a project that depends on human-review puts that project's
+ * `node_modules/.bin` there too. Either way a naive `which` succeeds and setup
+ * writes a bare `human-review` into a SKILL.md that is meant to work from any
+ * directory. The entry drops off PATH as soon as the runner exits, or stops
+ * resolving as soon as the agent runs from somewhere else.
  */
 export function invocation(run = spawnSync) {
   const probe = process.platform === "win32" ? "where" : "which";
   const found = run(probe, ["human-review"], { encoding: "utf8", windowsHide: true });
   const resolved = found.status === 0 ? found.stdout.trim().split(/\r?\n/)[0].trim() : "";
-  return resolved && !isNpxCachePath(resolved) ? "human-review" : "npx -y human-review";
+  return resolved && !isTransientBin(resolved) ? "human-review" : "npx -y human-review";
 }
 
-/** True for a binary npm placed in its transient `_npx` cache for one command. */
-export function isNpxCachePath(binPath) {
-  return binPath.split(/[\\/]/).includes("_npx");
+/**
+ * True for a bin that exists only for one command or only inside one project.
+ * Every transient channel routes through a `node_modules` directory: `npx`,
+ * `pnpm dlx`, `yarn dlx`, `bunx`, and a plain project-local dependency. npm's
+ * npx cache additionally sits under `_npx`, which is worth keeping as its own
+ * check because npm may relocate the bin inside it. Durable installs resolve
+ * through a bin directory with neither segment: `npm i -g`, `npm link`, volta,
+ * nvm, asdf, and the pnpm and yarn globals.
+ *
+ * A durable path that happens to contain either segment degrades to the npx
+ * form, which always works, so the failure direction here is cosmetic.
+ */
+export function isTransientBin(binPath) {
+  const segments = binPath.split(/[\\/]/);
+  return segments.includes("_npx") || segments.includes("node_modules");
 }
 
 /**

--- a/src/setup.js
+++ b/src/setup.js
@@ -50,16 +50,17 @@ const CODEX_BLOCK = `
 After writing an HTML or Markdown file the user will read, open it for them with
 \`npx -y human-review <file.html>\`. For a locally running web page, open the real
 route with \`npx -y human-review http://localhost:3000/path\` instead of recreating
-it as a static file. Then block on
-\`npx -y human-review poll <target> --timeout 600\` until they send feedback.
-If it prints \`{"status":"timeout"}\`, no feedback arrived yet — run the same
-poll command again to keep waiting. When a \`{"status":"feedback"}\` batch
-arrives, apply it, then poll again with \`--ack\`.
+it as a static file. Then start
+\`npx -y human-review poll <target>\` in the background and end the turn: it
+blocks until the user hits Send, prints the \`{"status":"feedback"}\` batch,
+and exits, which wakes you. Do not add \`--timeout\` and do not poll on an
+interval. Apply the batch, then start the next background poll with \`--ack\`.
+\`{"status":"closed"}\` means the user ended the review; do not poll again.
 
-Keep the poll command in the foreground and do not end the turn while it waits.
-If the shell returns a process or session handle, keep waiting on that handle until
-the command exits. \`npx -y human-review status <target>\` reports instantly
-whether feedback is already waiting, without blocking.
+Only if your harness cannot wake you when a background command exits, keep the
+poll in the foreground (or wait on the process handle it returns) until it
+exits. \`npx -y human-review status <target>\` reports instantly whether
+feedback is already waiting, without blocking.
 
 The batch groups feedback by page under \`pages\`, so fix every page listed. Items
 under \`edits\` are changes the user already made: \`after\` is their exact wording,

--- a/src/setup.js
+++ b/src/setup.js
@@ -65,14 +65,19 @@ After writing an HTML or Markdown file the user will read, open it for them with
 \`npx -y human-review <file.html>\`. For a locally running web page, open the real
 route with \`npx -y human-review http://localhost:3000/path\` instead of recreating
 it as a static file. Then run
-\`npx -y human-review poll <target>\` in the foreground and stay on it: it
-blocks until the user hits Send, prints the \`{"status":"feedback"}\` batch,
-and exits. Do not detach it or start it as a background session — nothing
-wakes you when a detached command finishes, so the user's Send would sit
-unread. Do not poll on an interval. If your shell tool enforces a maximum
-command duration, pass \`--timeout\` a little under that limit and run the
-same command again on \`{"status":"timeout"}\`. Apply the batch, then run
-the poll again with \`--ack\`.
+\`npx -y human-review poll <target>\` in the foreground, inside your active
+turn, and stay on it until it prints \`{"status":"feedback"}\` or
+\`{"status":"closed"}\`. Do not detach it or start it as a background
+session: nothing wakes you when a detached command finishes. While the review
+is active, answer any incoming user message as commentary and immediately
+resume the foreground poll in the same turn; do not send a final response
+until the poll returns feedback or closed, because a final response ends the
+turn and kills the wait. If your shell tool caps command duration, pass
+\`--timeout\` a little under the cap and run bounded polls back to back in
+the same active turn. Apply the batch, then run the poll again with
+\`--ack\`. This is reliable only while the turn stays active: a turn that
+already ended is not woken by Send, and the user has to message you, after
+which \`status\` and \`poll\` pick the batch up.
 \`{"status":"closed"}\` means the review is over (ended, tab closed, or none
 open); do not poll again, and if its \`unsent\` counts are not zero, tell the user
 in one line. \`{"status":"superseded"}\` means a newer poll of yours owns the

--- a/src/state.js
+++ b/src/state.js
@@ -107,8 +107,8 @@ function writeThroughTmp(file, data, overrides) {
  *
  * Shape:
  *   {
- *     pages:   { <key>: { key, file, pristine, comments[], edits[], updatedAt } },
- *     batches: { <entryKey>: { batch, cleanup, updatedAt } },
+ *     pages:   { <key>: { key, file, pristine, dynamic, comments[], edits[], updatedAt } },
+ *     batches: { <entryKey>: { batch, cleanup, delivered, priorCleanup, updatedAt } },
  *   }
  *
  * Pages are fully independent: no page ever references another. Batches are
@@ -265,17 +265,51 @@ export class Store {
     });
   }
 
-  /** Rewording feedback before it is sent. Returns null for an unknown id. */
-  updateComment(key, id, feedback) {
+  /**
+   * Reword feedback. A comment the agent already received keeps the old id in
+   * that batch's cleanup, so the reworded one takes a fresh id (`newId`) and
+   * survives the ack to ship with the next Send. Returns null for an unknown id.
+   */
+  updateComment(key, id, feedback, { newId = "" } = {}) {
     let found = false;
     const page = this.update(key, (p) => {
       const comment = p.comments.find((c) => c.id === id);
       if (comment) {
         comment.feedback = feedback;
+        comment.updatedAt = Date.now();
+        if (newId) comment.id = newId;
         found = true;
       }
     });
     return found ? page : null;
+  }
+
+  /** Undo of a delete or move: the row for that block no longer describes anything. */
+  removeEdit(key, label, kind) {
+    return this.update(key, (page) => {
+      page.edits = page.edits.filter((e) => !(e.label === label && e.kind === kind));
+    });
+  }
+
+  /** The user abandoned leftover feedback from an earlier review of this page. */
+  discardFeedback(key) {
+    return this.update(key, (page) => {
+      page.comments = [];
+      page.edits = [];
+    });
+  }
+
+  /**
+   * A self-rendering HTML file: its scripts rewrite the DOM, so browser edits
+   * are feedback only and never on disk. Remembered so the batch can say so.
+   */
+  setDynamic(key, dynamic) {
+    const page = this.page(key);
+    if (!page || !!page.dynamic === !!dynamic) return page;
+    return this.update(key, (p) => {
+      if (dynamic) p.dynamic = true;
+      else delete p.dynamic;
+    });
   }
 
   /**
@@ -309,11 +343,16 @@ export class Store {
     });
   }
 
-  /** After the agent writes, its version becomes the new revert target. */
-  setPristine(key, html) {
+  /**
+   * After the agent writes, its version becomes the new revert target. Edit
+   * rows are dropped only when they were already written into the file: on a
+   * Markdown or self-rendering page they are unsent feedback, and an external
+   * write (an editor autosave, a formatter) must not throw them away.
+   */
+  setPristine(key, html, { keepEdits = false } = {}) {
     return this.update(key, (page) => {
       page.pristine = html;
-      page.edits = [];
+      if (!keepEdits) page.edits = [];
     });
   }
 
@@ -342,10 +381,44 @@ export class Store {
     return this.data.batches;
   }
 
-  setBatch(entryKey, { batch, cleanup }) {
+  setBatch(entryKey, { batch, cleanup, delivered = false, priorCleanup = null }) {
     this.clearedBatches.delete(entryKey);
-    this.data.batches[entryKey] = { batch, cleanup, updatedAt: Date.now() };
+    this.data.batches[entryKey] = {
+      batch,
+      cleanup,
+      delivered: !!delivered,
+      ...(priorCleanup && priorCleanup.length ? { priorCleanup } : {}),
+      updatedAt: Date.now(),
+    };
     this.save();
+  }
+
+  /**
+   * Delivery is durable: a server replaced between handing a batch out and
+   * the agent's --ack must still honor that ack, not ship the batch twice.
+   */
+  markDelivered(entryKey) {
+    const record = this.data.batches[entryKey];
+    if (!record || record.delivered) return;
+    record.delivered = true;
+    record.updatedAt = Date.now();
+    this.save();
+  }
+
+  /**
+   * A batch another server process wrote (two servers briefly overlapping)
+   * lives only on disk. Read it fresh so a poll here can still deliver it.
+   */
+  batchFromDisk(entryKey) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(statePath(), "utf8"));
+      const record = parsed && parsed.batches ? parsed.batches[entryKey] : null;
+      if (!record || this.clearedBatches.has(entryKey)) return null;
+      this.data.batches[entryKey] = record;
+      return record;
+    } catch {
+      return null;
+    }
   }
 
   clearBatch(entryKey) {

--- a/src/state.js
+++ b/src/state.js
@@ -1,7 +1,30 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { canonicalTarget, ensureStateDir, pageKey, realFile, statePath, targetKey } from "./paths.js";
+import { canonicalTarget, ensureStateDir, pageKey, realFile, stateDir, statePath, targetKey } from "./paths.js";
+
+/**
+ * The agent's copy of each page is the revert target. It is whole documents,
+ * so it lives in its own file per page rather than inside state.json, which
+ * every edit flush rewrites in full.
+ */
+const pristineDir = () => path.join(stateDir(), "pristine");
+const pristinePath = (key) => path.join(pristineDir(), `${key}.html`);
+const digest = (text) => crypto.createHash("sha1").update(text).digest("hex");
+
+function readPristine(key) {
+  try {
+    return fs.readFileSync(pristinePath(key), "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function dropPristine(key) {
+  try {
+    fs.unlinkSync(pristinePath(key));
+  } catch {}
+}
 
 /** Anything untouched this long is review debris, not work in progress. */
 const PRUNE_AGE_MS = 30 * 24 * 60 * 60 * 1000;
@@ -120,6 +143,8 @@ export class Store {
     this.data = { pages: {}, batches: {} };
     /** Batches this process acked; save() must not resurrect them from disk. */
     this.clearedBatches = new Set();
+    /** Digest of the pristine copy already on disk per page; unchanged copies are not rewritten. */
+    this.pristineWritten = new Map();
     this.load();
   }
 
@@ -133,6 +158,13 @@ export class Store {
     } catch {
       // Missing or unreadable state is not an error; start empty.
     }
+    for (const [key, page] of Object.entries(this.data.pages)) {
+      // A state file from before pristine copies moved out still embeds
+      // them; that copy is kept and lands in its own file on the next save.
+      if (typeof page.pristine === "string") continue;
+      page.pristine = readPristine(key);
+      if (page.pristine) this.pristineWritten.set(key, digest(page.pristine));
+    }
     this.prune();
     return this.data;
   }
@@ -145,6 +177,7 @@ export class Store {
       if (!fresh(page, now) || missingFile) {
         delete this.data.pages[key];
         delete this.data.batches[key];
+        dropPristine(key);
       }
     }
     for (const [key, batch] of Object.entries(this.data.batches)) {
@@ -167,15 +200,29 @@ export class Store {
     } catch {
       // No readable state yet; ours becomes the file.
     }
+    const stripped = {};
+    for (const [key, page] of Object.entries(this.data.pages)) {
+      const { pristine, ...rest } = page;
+      stripped[key] = rest;
+      if (typeof pristine !== "string" || !pristine) continue;
+      const hash = digest(pristine);
+      if (this.pristineWritten.get(key) === hash) continue;
+      fs.mkdirSync(pristineDir(), { recursive: true });
+      atomicWrite(pristinePath(key), pristine);
+      this.pristineWritten.set(key, hash);
+    }
     const merged = {
-      pages: { ...onDisk.pages, ...this.data.pages },
+      pages: { ...onDisk.pages, ...stripped },
       batches: { ...onDisk.batches, ...this.data.batches },
     };
     for (const key of this.clearedBatches) delete merged.batches[key];
     // Age-prune the merged result too, so the file cannot grow without bound.
     const now = Date.now();
     for (const [key, page] of Object.entries(merged.pages)) {
-      if (!fresh(page, now)) delete merged.pages[key];
+      if (!fresh(page, now)) {
+        delete merged.pages[key];
+        dropPristine(key);
+      }
     }
     for (const [key, batch] of Object.entries(merged.batches)) {
       if (!fresh(batch, now)) delete merged.batches[key];

--- a/src/state.js
+++ b/src/state.js
@@ -9,19 +9,95 @@ const PRUNE_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const fresh = (entry, now) => !!entry && now - (entry.updatedAt || 0) < PRUNE_AGE_MS;
 
 /**
+ * Windows lets a virus scanner or indexer hold a brief handle on a file the
+ * moment it is created, and a rename against that handle fails with EPERM,
+ * EACCES or EBUSY. The handle is gone within a few milliseconds, so the write
+ * is not really lost -- it just has to be asked for again. Measured on a box
+ * running McAfee real-time protection, ~4% of renames failed on the first try
+ * and none survived a short backoff.
+ */
+const RETRYABLE_RENAME = new Set(["EPERM", "EACCES", "EBUSY"]);
+const RENAME_TRIES = 5;
+
+/** Sleep without going async: atomicWrite is synchronous by contract. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Drop the temp file after a failed write. The handle that blocked the rename
+ * blocks the unlink for exactly as long, so a single attempt would strand the
+ * file in the state directory -- and nothing else ever sweeps it. Give up
+ * quietly once the retries are spent: the caller is already throwing the error
+ * that matters, and a leftover temp file must not mask it.
+ */
+function discardTmp(tmp, unlink, sleep) {
+  try {
+    for (let attempt = 0; attempt < RENAME_TRIES; attempt++) {
+      try {
+        unlink(tmp);
+        return;
+      } catch (err) {
+        if (err.code === "ENOENT" || !RETRYABLE_RENAME.has(err.code)) return;
+        // Nothing waits on the last attempt: no attempt follows it.
+        if (attempt === RENAME_TRIES - 1) return;
+        sleep(2 ** attempt);
+      }
+    }
+  } catch {
+    // Best effort by definition. Whatever failed in here -- including the
+    // sleep -- must never escape and replace the write error the caller is
+    // already throwing.
+  }
+}
+
+/**
  * Atomic write via a unique sibling tmp file. The name is unguessable and the
  * create is exclusive, so a pre-planted symlink can never redirect the write,
  * and a failed rename never leaves a predictable orphan behind.
  */
 export function atomicWrite(file, data) {
+  return writeThroughTmp(file, data, REAL);
+}
+
+/**
+ * The real calls, looked up at call time rather than captured here, so a test
+ * can drive the exported atomicWrite through its retry by patching fs.
+ */
+const REAL = {
+  rename: (from, to) => fs.renameSync(from, to),
+  unlink: (target) => fs.unlinkSync(target),
+  sleep: (ms) => sleepSync(ms),
+};
+
+/**
+ * atomicWrite's body. Private: nothing outside this module may hand it a
+ * rename that quietly does nothing and reports a successful write. Tests
+ * reach the retry by patching fs, which REAL looks up at call time.
+ */
+function writeThroughTmp(file, data, overrides) {
+  // Merged per key, so a test can replace one call and still exercise the
+  // real implementations of the others.
+  const { rename, unlink, sleep } = { ...REAL, ...overrides };
   const tmp = `${file}.${process.pid}.${crypto.randomBytes(6).toString("hex")}.human-review.tmp`;
   fs.writeFileSync(tmp, data, { flag: "wx" });
   try {
-    fs.renameSync(tmp, file);
+    for (let attempt = 0; ; attempt++) {
+      try {
+        rename(tmp, file);
+        return;
+      } catch (err) {
+        if (attempt >= RENAME_TRIES - 1 || !RETRYABLE_RENAME.has(err.code)) throw err;
+        try {
+          sleep(2 ** attempt);
+        } catch {
+          // A broken sleeper is not the failure worth reporting.
+          throw err;
+        }
+      }
+    }
   } catch (err) {
-    try {
-      fs.unlinkSync(tmp);
-    } catch {}
+    discardTmp(tmp, unlink, sleep);
     throw err;
   }
 }

--- a/test/agent-loop.test.js
+++ b/test/agent-loop.test.js
@@ -80,17 +80,11 @@ async function waitForServer(notPid) {
 }
 
 async function stop(child) {
-  if (child.exitCode !== null) return;
+  // A child killed by a signal exits with a null code and a signalCode; on
+  // Windows a second stop() would then wait forever for an exit it already saw.
+  if (child.exitCode !== null || child.signalCode !== null) return;
   child.kill();
-  // Windows occasionally never reports the exit of a terminated child; a
-  // bounded wait keeps one stuck handle from stalling the whole file.
   await Promise.race([once(child, "exit"), new Promise((resolve) => setTimeout(resolve, 5000))]);
-  if (child.exitCode === null) {
-    try {
-      child.kill("SIGKILL");
-    } catch {}
-    await Promise.race([once(child, "exit"), new Promise((resolve) => setTimeout(resolve, 2000))]);
-  }
 }
 
 // Flat, sequential top-level tests (no nested subtests): the nested form
@@ -153,18 +147,14 @@ test("a restarted server still delivers the sent batch", async () => {
 });
 
 test("an open-ended poll reconnects when the server is replaced underneath it", async () => {
-  const mark = (step) => console.error(`[reconnect ${new Date().toISOString()}] ${step}`);
-  mark("spawn third");
   const third = spawnServer();
   let fourth = null;
   try {
     const thirdRecord = await waitForServer(server.pid);
-    mark(`third up pid=${thirdRecord.pid}`);
     // The previous test's batch is still pending (delivered, never acked).
     // Take it once so the CLI's --ack below clears it and the poll blocks;
     // a plain poll with nothing pending would wait forever, so check first.
     const status = await request(thirdRecord, "GET", `/api/status?target=${encodeURIComponent(file)}`);
-    mark(`status on third: ${JSON.stringify(status.body)}`);
     if (status.body.feedback_waiting) await request(thirdRecord, "GET", `/api/poll?target=${encodeURIComponent(file)}`);
     // No --timeout: this is the wait an agent parks in the background.
     const poll = cli("poll", file, "--ack");
@@ -174,18 +164,14 @@ test("an open-ended poll reconnects when the server is replaced underneath it", 
     });
     for (let i = 0; i < 200 && !stderr.includes("Waiting for feedback"); i += 1) await new Promise((r) => setTimeout(r, 25));
     await new Promise((r) => setTimeout(r, 300));
-    mark(`poll attached: ${JSON.stringify(stderr)}`);
 
     await stop(third);
-    mark("third stopped");
     fs.rmSync(path.join(process.env.HUMAN_REVIEW_STATE_DIR, "server.json"), { force: true });
     fourth = spawnServer();
     const record = await waitForServer(thirdRecord.pid);
-    mark(`fourth up pid=${record.pid}; lock=${fs.existsSync(path.join(process.env.HUMAN_REVIEW_STATE_DIR, "server.lock"))}`);
     assert.equal(poll.exitCode, null, `poll exited early: ${stderr}`);
 
     const opened = await request(record, "POST", "/api/session", { file });
-    mark("session opened on fourth");
     await request(record, "POST", `/api/page/${opened.body.key}/comment`, {
       kind: "selection",
       quote: "Original",
@@ -193,7 +179,6 @@ test("an open-ended poll reconnects when the server is replaced underneath it", 
     });
     await request(record, "POST", `/api/page/${opened.body.key}/send`, { sessionId: opened.body.sessionId, note: "" });
 
-    mark(`batch sent; poll stderr so far: ${JSON.stringify(stderr)}`);
     // A poll that attached to the wrong server would wait forever; fail
     // loudly instead of stalling the whole suite.
     const result = await Promise.race([
@@ -211,11 +196,8 @@ test("an open-ended poll reconnects when the server is replaced underneath it", 
     assert.equal(batch.pages[0].comments[0].feedback, "Still here after the restart.");
     assert.match(stderr + result.stderr, /reconnecting/);
   } finally {
-    mark(`cleanup: third exit=${third.exitCode} killed=${third.killed}; fourth exit=${fourth && fourth.exitCode} killed=${fourth && fourth.killed}`);
     await stop(third);
-    mark("third stop returned");
     if (fourth) await stop(fourth);
-    mark(`done: fourth exit=${fourth && fourth.exitCode}`);
   }
 });
 

--- a/test/agent-loop.test.js
+++ b/test/agent-loop.test.js
@@ -176,7 +176,17 @@ test("an open-ended poll reconnects when the server is replaced underneath it", 
     });
     await request(record, "POST", `/api/page/${opened.body.key}/send`, { sessionId: opened.body.sessionId, note: "" });
 
-    const result = await collect(poll);
+    // A poll that attached to the wrong server would wait forever; fail
+    // loudly instead of stalling the whole suite.
+    const result = await Promise.race([
+      collect(poll),
+      new Promise((_, reject) =>
+        setTimeout(() => {
+          poll.kill();
+          reject(new Error(`the reconnected poll never received the batch: ${stderr}`));
+        }, 30000)
+      ),
+    ]);
     assert.equal(result.code, 0, result.stderr);
     const batch = JSON.parse(result.stdout);
     assert.equal(batch.status, "feedback");

--- a/test/agent-loop.test.js
+++ b/test/agent-loop.test.js
@@ -80,9 +80,16 @@ async function waitForServer(notPid) {
 }
 
 async function stop(child) {
+  if (child.exitCode !== null) return;
+  child.kill();
+  // Windows occasionally never reports the exit of a terminated child; a
+  // bounded wait keeps one stuck handle from stalling the whole file.
+  await Promise.race([once(child, "exit"), new Promise((resolve) => setTimeout(resolve, 5000))]);
   if (child.exitCode === null) {
-    child.kill();
-    await once(child, "exit");
+    try {
+      child.kill("SIGKILL");
+    } catch {}
+    await Promise.race([once(child, "exit"), new Promise((resolve) => setTimeout(resolve, 2000))]);
   }
 }
 
@@ -204,10 +211,11 @@ test("an open-ended poll reconnects when the server is replaced underneath it", 
     assert.equal(batch.pages[0].comments[0].feedback, "Still here after the restart.");
     assert.match(stderr + result.stderr, /reconnecting/);
   } finally {
-    mark("cleanup");
+    mark(`cleanup: third exit=${third.exitCode} killed=${third.killed}; fourth exit=${fourth && fourth.exitCode} killed=${fourth && fourth.killed}`);
     await stop(third);
+    mark("third stop returned");
     if (fourth) await stop(fourth);
-    mark("done");
+    mark(`done: fourth exit=${fourth && fourth.exitCode}`);
   }
 });
 

--- a/test/agent-loop.test.js
+++ b/test/agent-loop.test.js
@@ -145,6 +145,49 @@ test("a restarted server still delivers the sent batch", async () => {
   }
 });
 
+test("an open-ended poll reconnects when the server is replaced underneath it", async () => {
+  const third = spawnServer();
+  let fourth = null;
+  try {
+    const thirdRecord = await waitForServer(server.pid);
+    // A fresh server reloads the old batch as undelivered, so deliver it once
+    // here; then the CLI's --ack clears it and the poll blocks.
+    await request(thirdRecord, "GET", `/api/poll?target=${encodeURIComponent(file)}`);
+    // No --timeout: this is the wait an agent parks in the background.
+    const poll = cli("poll", file, "--ack");
+    let stderr = "";
+    poll.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    for (let i = 0; i < 200 && !stderr.includes("Waiting for feedback"); i += 1) await new Promise((r) => setTimeout(r, 25));
+    await new Promise((r) => setTimeout(r, 300));
+
+    await stop(third);
+    fs.rmSync(path.join(process.env.HUMAN_REVIEW_STATE_DIR, "server.json"), { force: true });
+    fourth = spawnServer();
+    const record = await waitForServer(thirdRecord.pid);
+    assert.equal(poll.exitCode, null, `poll exited early: ${stderr}`);
+
+    const opened = await request(record, "POST", "/api/session", { file });
+    await request(record, "POST", `/api/page/${opened.body.key}/comment`, {
+      kind: "selection",
+      quote: "Original",
+      feedback: "Still here after the restart.",
+    });
+    await request(record, "POST", `/api/page/${opened.body.key}/send`, { sessionId: opened.body.sessionId, note: "" });
+
+    const result = await collect(poll);
+    assert.equal(result.code, 0, result.stderr);
+    const batch = JSON.parse(result.stdout);
+    assert.equal(batch.status, "feedback");
+    assert.equal(batch.pages[0].comments[0].feedback, "Still here after the restart.");
+    assert.match(stderr + result.stderr, /reconnecting/);
+  } finally {
+    await stop(third);
+    if (fourth) await stop(fourth);
+  }
+});
+
 test.after(async () => {
   await stop(first);
   fs.rmSync(tmp, { recursive: true, force: true });

--- a/test/agent-loop.test.js
+++ b/test/agent-loop.test.js
@@ -146,13 +146,19 @@ test("a restarted server still delivers the sent batch", async () => {
 });
 
 test("an open-ended poll reconnects when the server is replaced underneath it", async () => {
+  const mark = (step) => console.error(`[reconnect ${new Date().toISOString()}] ${step}`);
+  mark("spawn third");
   const third = spawnServer();
   let fourth = null;
   try {
     const thirdRecord = await waitForServer(server.pid);
-    // A fresh server reloads the old batch as undelivered, so deliver it once
-    // here; then the CLI's --ack clears it and the poll blocks.
-    await request(thirdRecord, "GET", `/api/poll?target=${encodeURIComponent(file)}`);
+    mark(`third up pid=${thirdRecord.pid}`);
+    // The previous test's batch is still pending (delivered, never acked).
+    // Take it once so the CLI's --ack below clears it and the poll blocks;
+    // a plain poll with nothing pending would wait forever, so check first.
+    const status = await request(thirdRecord, "GET", `/api/status?target=${encodeURIComponent(file)}`);
+    mark(`status on third: ${JSON.stringify(status.body)}`);
+    if (status.body.feedback_waiting) await request(thirdRecord, "GET", `/api/poll?target=${encodeURIComponent(file)}`);
     // No --timeout: this is the wait an agent parks in the background.
     const poll = cli("poll", file, "--ack");
     let stderr = "";
@@ -161,14 +167,18 @@ test("an open-ended poll reconnects when the server is replaced underneath it", 
     });
     for (let i = 0; i < 200 && !stderr.includes("Waiting for feedback"); i += 1) await new Promise((r) => setTimeout(r, 25));
     await new Promise((r) => setTimeout(r, 300));
+    mark(`poll attached: ${JSON.stringify(stderr)}`);
 
     await stop(third);
+    mark("third stopped");
     fs.rmSync(path.join(process.env.HUMAN_REVIEW_STATE_DIR, "server.json"), { force: true });
     fourth = spawnServer();
     const record = await waitForServer(thirdRecord.pid);
+    mark(`fourth up pid=${record.pid}; lock=${fs.existsSync(path.join(process.env.HUMAN_REVIEW_STATE_DIR, "server.lock"))}`);
     assert.equal(poll.exitCode, null, `poll exited early: ${stderr}`);
 
     const opened = await request(record, "POST", "/api/session", { file });
+    mark("session opened on fourth");
     await request(record, "POST", `/api/page/${opened.body.key}/comment`, {
       kind: "selection",
       quote: "Original",
@@ -176,6 +186,7 @@ test("an open-ended poll reconnects when the server is replaced underneath it", 
     });
     await request(record, "POST", `/api/page/${opened.body.key}/send`, { sessionId: opened.body.sessionId, note: "" });
 
+    mark(`batch sent; poll stderr so far: ${JSON.stringify(stderr)}`);
     // A poll that attached to the wrong server would wait forever; fail
     // loudly instead of stalling the whole suite.
     const result = await Promise.race([
@@ -193,8 +204,10 @@ test("an open-ended poll reconnects when the server is replaced underneath it", 
     assert.equal(batch.pages[0].comments[0].feedback, "Still here after the restart.");
     assert.match(stderr + result.stderr, /reconnecting/);
   } finally {
+    mark("cleanup");
     await stop(third);
     if (fourth) await stop(fourth);
+    mark("done");
   }
 });
 

--- a/test/asset-paste.test.js
+++ b/test/asset-paste.test.js
@@ -145,7 +145,7 @@ test("localhost image pastes are staged, previewed, and delivered to the agent",
   });
   assert.equal(pasted.status, 200, pasted.raw);
   const asset = JSON.parse(pasted.raw);
-  assert.equal(asset.src, `/artifact/${opened.key}/__human_review_paste__/localhost-paste-1.png`);
+  assert.equal(asset.src, `/artifact/${opened.artifactToken}/${opened.key}/__human_review_paste__/localhost-paste-1.png`);
   assert.equal(asset.stagedId, "localhost-paste-1.png");
   const stagedPath = path.join(process.env.HUMAN_REVIEW_STATE_DIR, "pasted", opened.key, asset.stagedId);
   assert.deepEqual(fs.readFileSync(stagedPath), PNG);

--- a/test/feedback-safety.test.js
+++ b/test/feedback-safety.test.js
@@ -217,7 +217,7 @@ test("ending a review releases the waiting agent and keeps unsent feedback", asy
 
   const answer = JSON.parse((await polled).raw);
   assert.equal(answer.status, "closed", "the poller is released, not left to time out");
-  assert.match(answer.next_step, /Stop polling/);
+  assert.match(answer.next_step, /do not run the poll command again/);
 
   const gone = await request(port, token, { route: `/api/session/${opened.sessionId}/page` });
   assert.equal(gone.status, 404, "the session is forgotten");

--- a/test/frame-policy.test.js
+++ b/test/frame-policy.test.js
@@ -19,3 +19,14 @@ test("file and Markdown reviews use an opaque origin", () => {
     assert.equal(policy.targetOrigin, "*");
   }
 });
+
+test("no review grants the frame popups or downloads", () => {
+  // The SDK hands external links to the chrome over postMessage, which opens
+  // them itself, so the frame never needs allow-popups. Nothing needs
+  // allow-downloads. Untrusted artifacts get neither.
+  for (const page of [{ kind: "url" }, { kind: "file", markdown: false }, { kind: "file", markdown: true }]) {
+    const policy = framePolicy(page, artifactOrigin);
+    assert.doesNotMatch(policy.sandbox, /\ballow-popups\b/);
+    assert.doesNotMatch(policy.sandbox, /\ballow-downloads\b/);
+  }
+});

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -1,0 +1,400 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-lifecycle-"));
+process.env.HUMAN_REVIEW_STATE_DIR = path.join(tmp, "state");
+// Short graces so the suite stays fast; the real values are seconds.
+process.env.HUMAN_REVIEW_CLOSE_GRACE_MS = "150";
+process.env.HUMAN_REVIEW_NO_REVIEW_GRACE_MS = "300";
+
+const { start } = await import("../src/server.js");
+
+function request(port, token, { method = "GET", route = "/", body = null, headers = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method,
+        path: route,
+        // Node's client only chunks bodies on POST/PUT/PATCH; a DELETE body
+        // needs an explicit length or it trails the request as garbage.
+        headers: {
+          ...(token ? { "x-human-review-token": token } : {}),
+          ...(body ? { "content-type": "application/json", "content-length": String(Buffer.byteLength(JSON.stringify(body))) } : {}),
+          ...headers,
+        },
+      },
+      (res) => {
+        let raw = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          raw += chunk;
+        });
+        res.on("end", () => resolve({ status: res.statusCode, raw, headers: res.headers }));
+      }
+    );
+    req.on("error", reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+const j = (res) => JSON.parse(res.raw);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** A long-poll as the CLI issues it. `.settled` says whether the server answered yet. */
+function poll(port, token, target, { ack = false } = {}) {
+  const state = { settled: false, req: null };
+  state.promise = new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: "127.0.0.1", port, path: `/api/poll?target=${encodeURIComponent(target)}${ack ? "&ack=1" : ""}`, headers: { "x-human-review-token": token } },
+      (res) => {
+        let raw = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          raw += chunk;
+        });
+        res.on("end", () => {
+          state.settled = true;
+          resolve(raw.trim() ? JSON.parse(raw) : null);
+        });
+      }
+    );
+    req.on("error", (err) => (state.settled ? null : reject(err)));
+    req.end();
+    state.req = req;
+  });
+  return state;
+}
+
+/** Hold an SSE connection open like a browser tab does. */
+function tab(port, sessionId) {
+  return new Promise((resolve) => {
+    const req = http.get({ host: "127.0.0.1", port, path: `/events/${sessionId}` }, (res) => {
+      res.on("data", () => {});
+      resolve({ close: () => req.destroy() });
+    });
+  });
+}
+
+async function open(port, token, target) {
+  return j(await request(port, token, { method: "POST", route: "/api/session", body: { target } }));
+}
+
+async function comment(port, token, key, quote, feedback) {
+  return j(await request(port, token, { method: "POST", route: `/api/page/${key}/comment`, body: { kind: "selection", quote, feedback } }));
+}
+
+async function edit(port, token, key, row) {
+  return j(await request(port, token, { method: "POST", route: `/api/page/${key}/edit`, body: { kind: "edited", ...row } }));
+}
+
+async function send(port, token, key, sessionId, note = "") {
+  return request(port, token, { method: "POST", route: `/api/page/${key}/send`, body: { sessionId, note } });
+}
+
+const htmlFile = (name, body = "<p>Alpha</p><p>Beta</p>") => {
+  const file = path.join(tmp, name);
+  fs.writeFileSync(file, `<!DOCTYPE html>\n<html><head></head><body>${body}</body></html>\n`);
+  return file;
+};
+
+test("closing the tab ends the review and releases the waiting poll with the unsent counts", async (t) => {
+  const file = htmlFile("close.html");
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+  const opened = await open(port, token, file);
+  const browser = await tab(port, opened.sessionId);
+  await comment(port, token, opened.key, "Alpha", "Left behind");
+  await edit(port, token, opened.key, { label: "p", before: "Beta", after: "Gamma" });
+
+  const waiting = poll(port, token, file);
+  await sleep(50);
+  assert.equal(waiting.settled, false);
+
+  // pagehide: the tab says it is leaving, then the connection drops.
+  await request(port, token, { method: "POST", route: `/api/session/${opened.sessionId}/away` });
+  browser.close();
+  const answer = await waiting.promise;
+  assert.equal(answer.status, "closed");
+  assert.equal(answer.reason, "window_closed");
+  assert.deepEqual(answer.unsent, { comments: 1, edits: 1 });
+  assert.match(answer.next_step, /do not run the poll command again/);
+  assert.match(answer.next_step, /2 unsent items/);
+
+  const gone = await request(port, token, { route: `/api/session/${opened.sessionId}/page` });
+  assert.equal(gone.status, 404, "the session is forgotten");
+  const page = j(await request(port, token, { route: `/api/page/${opened.key}` }));
+  assert.equal(page.comments.length, 1, "unsent feedback is kept for the next open");
+});
+
+test("a reload comes back inside the grace and nothing ends", async (t) => {
+  const file = htmlFile("reload.html");
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+  const opened = await open(port, token, file);
+  const first = await tab(port, opened.sessionId);
+  const waiting = poll(port, token, file);
+  await sleep(30);
+
+  await request(port, token, { method: "POST", route: `/api/session/${opened.sessionId}/away` });
+  first.close();
+  const second = await tab(port, opened.sessionId);
+  await sleep(300);
+  assert.equal(waiting.settled, false, "the poll is still waiting after the grace");
+  second.close();
+  waiting.req.destroy();
+});
+
+test("a poll with no review open closes after a short grace, unless one opens", async (t) => {
+  const file = htmlFile("noreview.html");
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+
+  const orphan = poll(port, token, file);
+  const answer = await orphan.promise;
+  assert.equal(answer.status, "closed");
+  assert.equal(answer.reason, "no_review_open");
+
+  const rescued = poll(port, token, file);
+  await sleep(100);
+  await open(port, token, file);
+  await sleep(350);
+  assert.equal(rescued.settled, false, "a review that opened inside the grace keeps the poll alive");
+  rescued.req.destroy();
+});
+
+test("a newer poll for the same target supersedes the older one", async (t) => {
+  const file = htmlFile("supersede.html");
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+  const opened = await open(port, token, file);
+  const older = poll(port, token, file);
+  await sleep(30);
+  const newer = poll(port, token, file);
+  const answer = await older.promise;
+  assert.equal(answer.status, "superseded");
+  await comment(port, token, opened.key, "Alpha", "Only once");
+  await send(port, token, opened.key, opened.sessionId);
+  const batch = await newer.promise;
+  assert.equal(batch.status, "feedback");
+  assert.equal(batch.pages[0].comments[0].feedback, "Only once");
+});
+
+test("sending while the agent works queues only the new items and one ack clears both", async (t) => {
+  const file = htmlFile("queue.html");
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+  const opened = await open(port, token, file);
+  const first = await comment(port, token, opened.key, "Alpha", "First round");
+  const waiting = poll(port, token, file);
+  await sleep(30);
+  await send(port, token, opened.key, opened.sessionId);
+  const batch1 = await waiting.promise;
+  assert.equal(batch1.pages[0].comments.length, 1);
+
+  // The agent is applying batch 1 (no poll open). A second Send must not
+  // say "nobody is listening", and must not re-ship the first comment.
+  await sleep(15);
+  await comment(port, token, opened.key, "Beta", "Second round");
+  const again = await send(port, token, opened.key, opened.sessionId);
+  assert.equal(again.status, 200, again.raw);
+  const status = j(await request(port, token, { route: `/api/status?target=${encodeURIComponent(file)}` }));
+  assert.equal(status.feedback_waiting, true);
+
+  // poll --ack: acks batch 1, delivers batch 2 with only the new comment.
+  const batch2 = await poll(port, token, file, { ack: true }).promise;
+  assert.equal(batch2.status, "feedback");
+  assert.deepEqual(batch2.pages[0].comments.map((c) => c.feedback), ["Second round"]);
+  let page = j(await request(port, token, { route: `/api/page/${opened.key}` }));
+  assert.deepEqual(page.comments.map((c) => c.feedback), ["Second round"], "the first batch's comment is cleared by that ack");
+  assert.ok(!page.comments.some((c) => c.id === first.comment.id));
+
+  const done = poll(port, token, file, { ack: true });
+  await sleep(50);
+  page = j(await request(port, token, { route: `/api/page/${opened.key}` }));
+  assert.deepEqual(page.comments, [], "the second ack clears the second batch");
+  done.req.destroy();
+});
+
+test("delivery survives a server restart so the ack is honored instead of re-shipping", async (t) => {
+  const file = htmlFile("restart.html");
+  const target = file;
+  let server = await start(0);
+  const opened = await open(server.port, server.token, file);
+  await comment(server.port, server.token, opened.key, "Alpha", "Once only");
+  await send(server.port, server.token, opened.key, opened.sessionId);
+  const delivered = await poll(server.port, server.token, target).promise;
+  assert.equal(delivered.status, "feedback");
+  server.dispose();
+  await sleep(50);
+
+  server = await start(0);
+  t.after(() => server.dispose());
+  const after = poll(server.port, server.token, target, { ack: true });
+  await sleep(100);
+  assert.equal(after.settled, false, "the ack cleared the batch instead of delivering it again");
+  const page = j(await request(server.port, server.token, { route: `/api/page/${opened.key}` }));
+  assert.deepEqual(page.comments, []);
+  after.req.destroy();
+});
+
+test("edit text is cut with an explicit marker instead of silently at 4k", async (t) => {
+  const file = htmlFile("long.html");
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+  const opened = await open(port, token, file);
+  const long = "x".repeat(6000);
+  const page = await edit(port, token, opened.key, { label: "p", before: "Alpha", after: long, after_html: `<p>${long}</p>` });
+  assert.equal(page.page.edits[0].after, long, "6k is well under the cap");
+  const huge = "y".repeat(250000);
+  const cut = await edit(port, token, opened.key, { label: "p 2", before: "Beta", after: huge });
+  const row = cut.page.edits.find((e) => e.label === "p 2");
+  assert.equal(row.truncated, true);
+  assert.match(row.after, /…\[truncated by human-review\]$/);
+  await send(port, token, opened.key, opened.sessionId);
+  const batch = await poll(port, token, file).promise;
+  assert.equal(batch.pages[0].edits.find((e) => e.label === "p 2").truncated, true);
+  assert.match(batch.next_step, /truncated/);
+});
+
+test("an external write keeps unsent edit rows on a Markdown page and drops them on an HTML file", async (t) => {
+  const md = path.join(tmp, "notes.md");
+  fs.writeFileSync(md, "# Notes\n\nFirst.\n");
+  const html = htmlFile("external.html");
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+  const mdPage = await open(port, token, md);
+  const htmlPage = await open(port, token, html);
+  await edit(port, token, mdPage.key, { label: "Notes · p", before: "First.", after: "Second." });
+  await edit(port, token, htmlPage.key, { label: "p", before: "Alpha", after: "Omega" });
+  await sleep(50);
+  fs.writeFileSync(md, "# Notes\n\nFirst, formatted by an editor.\n");
+  fs.writeFileSync(html, "<!DOCTYPE html>\n<html><head></head><body><p>Rewritten by the agent</p></body></html>\n");
+  // fs.watchFile polls every 400ms.
+  await sleep(1300);
+  const mdState = j(await request(port, token, { route: `/api/page/${mdPage.key}` }));
+  assert.equal(mdState.edits.length, 1, "Markdown edits are unsent feedback and survive");
+  const htmlState = j(await request(port, token, { route: `/api/page/${htmlPage.key}` }));
+  assert.equal(htmlState.edits.length, 0, "HTML edits were in the file the agent replaced");
+});
+
+test("undo removes the edit row; discard clears leftover feedback", async (t) => {
+  const file = htmlFile("undo.html");
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+  const opened = await open(port, token, file);
+  await request(port, token, { method: "POST", route: `/api/page/${opened.key}/edit`, body: { label: "p", kind: "deleted", before: "Alpha", after: "" } });
+  await edit(port, token, opened.key, { label: "p 2", before: "Beta", after: "Gamma" });
+  let page = j(await request(port, token, { method: "DELETE", route: `/api/page/${opened.key}/edit`, body: { label: "p", kind: "deleted" } })).page;
+  assert.deepEqual(page.edits.map((e) => e.label), ["p 2"]);
+  await comment(port, token, opened.key, "Beta", "Old thought");
+
+  // A later open reports what was left behind, and discard wipes it.
+  const reopened = await open(port, token, file);
+  assert.deepEqual(reopened.leftover, { comments: 1, edits: 1 });
+  page = j(await request(port, token, { method: "POST", route: `/api/page/${opened.key}/discard` })).page;
+  assert.deepEqual(page.comments, []);
+  assert.deepEqual(page.edits, []);
+  const fresh = await open(port, token, file);
+  assert.deepEqual(fresh.leftover, { comments: 0, edits: 0 });
+});
+
+test("rewording a comment updates a waiting batch in place and takes a new id after delivery", async (t) => {
+  const file = htmlFile("reword.html");
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+  const opened = await open(port, token, file);
+  const added = await comment(port, token, opened.key, "Alpha", "Delete this");
+  await send(port, token, opened.key, opened.sessionId);
+  const pending = j(await request(port, token, { method: "PATCH", route: `/api/page/${opened.key}/comment/${added.comment.id}`, body: { feedback: "Shorten this" } }));
+  assert.equal(pending.delivery, "updated-pending");
+  const batch = await poll(port, token, file).promise;
+  assert.equal(batch.pages[0].comments[0].feedback, "Shorten this");
+
+  const after = j(await request(port, token, { method: "PATCH", route: `/api/page/${opened.key}/comment/${added.comment.id}`, body: { feedback: "Keep it, add an example" } }));
+  assert.equal(after.delivery, "resend");
+  assert.notEqual(after.page.comments[0].id, added.comment.id, "the delivered id is retired so the ack cannot clear the rewrite");
+  assert.equal(typeof after.page.comments[0].updatedAt, "number");
+  const acked = poll(port, token, file, { ack: true });
+  await sleep(50);
+  const page = j(await request(port, token, { route: `/api/page/${opened.key}` }));
+  assert.deepEqual(page.comments.map((c) => c.feedback), ["Keep it, add an example"]);
+  acked.req.destroy();
+});
+
+test("a self-rendering page reports edits_saved: false", async (t) => {
+  const file = htmlFile("dynamic.html");
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+  const opened = await open(port, token, file);
+  await request(port, token, { method: "POST", route: `/api/page/${opened.key}/mode`, body: { dynamic: true } });
+  await edit(port, token, opened.key, { label: "p", before: "Alpha", after: "Rendered" });
+  await send(port, token, opened.key, opened.sessionId);
+  const batch = await poll(port, token, file).promise;
+  assert.equal(batch.pages[0].edits_saved, false);
+  assert.doesNotMatch(batch.next_step, /edits_saved: true/);
+});
+
+test("the artifact route needs the per-run secret, and a localhost app's own requests are proxied", async (t) => {
+  const app = http.createServer((req, res) => {
+    if (req.url === "/wiki") {
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      return res.end('<!doctype html><html><body><img srcset="/a.png 1x, /b.png 2x"><p>Hi</p></body></html>');
+    }
+    if (req.url === "/api/hello?x=1" && req.method === "POST") {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "application/json", "set-cookie": "app=1", "x-frame-options": "DENY" });
+        res.end(JSON.stringify({ hello: "from the app", got: body, host: req.headers.host }));
+      });
+      return undefined;
+    }
+    res.writeHead(200, { "content-type": "text/css" });
+    return res.end(`/* ${req.url} */`);
+  });
+  await new Promise((resolve) => app.listen(0, "127.0.0.1", resolve));
+  t.after(() => app.close());
+  const target = `http://localhost:${app.address().port}/wiki`;
+
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+  const opened = await open(port, token, target);
+
+  const noSecret = await request(port, "", { route: `/artifact/${opened.key}/index.html` });
+  assert.equal(noSecret.status, 404);
+  const page = await request(port, "", { route: `/artifact/${opened.artifactToken}/${opened.key}/index.html` });
+  assert.equal(page.status, 200);
+  assert.match(page.raw, new RegExp(`srcset="http://localhost:${app.address().port}/a.png 1x, http://localhost:${app.address().port}/b.png 2x"`));
+  assert.match(String(page.headers["set-cookie"]), /__hr_page=/);
+
+  const css = await request(port, "", { route: `/artifact/${opened.artifactToken}/${opened.key}/_next/wiki.css` });
+  assert.equal(css.status, 200);
+  assert.equal(css.raw, "/* /_next/wiki.css */");
+
+  const proxied = await request(port, "", {
+    method: "POST",
+    route: "/api/hello?x=1",
+    headers: { cookie: `__hr_page=${opened.key}`, "content-type": "text/plain" },
+    body: { ping: true },
+  });
+  assert.equal(proxied.status, 200, proxied.raw);
+  const answer = j(proxied);
+  assert.equal(answer.hello, "from the app");
+  assert.equal(answer.got, JSON.stringify({ ping: true }));
+  assert.equal(answer.host, `localhost:${app.address().port}`);
+  assert.equal(proxied.headers["set-cookie"], undefined, "app cookies do not land on the review origin");
+  assert.equal(proxied.headers["x-frame-options"], undefined);
+
+  // With the token it is our API, not the app's.
+  const ours = await request(port, token, { route: "/api/hello?x=1", headers: { cookie: `__hr_page=${opened.key}` } });
+  assert.equal(ours.status, 404);
+});
+
+test.after(() => fs.rmSync(tmp, { recursive: true, force: true }));

--- a/test/markdown.test.js
+++ b/test/markdown.test.js
@@ -97,10 +97,10 @@ test("a markdown review is rendered, flagged, and never writable", async (t) => 
 
   const opened = await request(port, token, { method: "POST", route: "/api/session", body: { file } });
   assert.equal(opened.status, 200);
-  const { key, sessionId } = JSON.parse(opened.raw);
+  const { key, sessionId, artifactToken } = JSON.parse(opened.raw);
 
   await t.test("the artifact route serves rendered html with the sdk injected", async () => {
-    const res = await request(port, token, { route: `/artifact/${key}/index.html` });
+    const res = await request(port, token, { route: `/artifact/${artifactToken}/${key}/index.html` });
     assert.equal(res.status, 200);
     assert.match(res.raw, /<h1[^>]*>Notes<\/h1>/);
     assert.match(res.raw, /data-eh-sdk/);

--- a/test/sdk.test.js
+++ b/test/sdk.test.js
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// jsdom (a dev dependency) needs Node 22+; the library itself supports Node 20.
+let JSDOM = null;
+try {
+  ({ JSDOM } = await import("jsdom"));
+} catch {
+  JSDOM = null;
+}
+const skip = JSDOM ? false : "jsdom unavailable on this Node version";
+
+const CHROME_ORIGIN = "http://localhost:4000";
+let seq = 0;
+
+/**
+ * Boot the editor SDK against a jsdom document standing in for the review
+ * iframe. The SDK talks to the chrome only through parent.postMessage, and
+ * jsdom's parent is the window itself, so patching postMessage captures
+ * every row it reports. Each boot re-imports the module with a cache-busting
+ * query so module-level state starts fresh.
+ */
+async function bootSdk(body) {
+  const dom = new JSDOM(`<!DOCTYPE html><html><head></head><body>${body}</body></html>`, {
+    url: "http://127.0.0.1:4000/artifact/t/k/index.html",
+    pretendToBeVisual: true,
+  });
+  const { window } = dom;
+  const posts = [];
+  window.postMessage = (message) => posts.push(JSON.parse(JSON.stringify(message)));
+  if (!window.CSS) window.CSS = {};
+  if (!window.CSS.escape) window.CSS.escape = (value) => String(value).replace(/[^\w-]/g, (c) => `\\${c}`);
+  for (const name of Object.getOwnPropertyNames(window)) {
+    if (name === "undefined" || name in globalThis) continue;
+    try {
+      globalThis[name] = window[name];
+    } catch {}
+  }
+  Object.assign(globalThis, {
+    window,
+    document: window.document,
+    location: window.location,
+    parent: window,
+    getComputedStyle: window.getComputedStyle.bind(window),
+    requestAnimationFrame: window.requestAnimationFrame.bind(window),
+    CSS: window.CSS,
+    NodeFilter: window.NodeFilter,
+    MutationObserver: window.MutationObserver,
+    DOMParser: window.DOMParser,
+  });
+  seq += 1;
+  await import(`../src/sdk.js?boot=${seq}`);
+  const fromChrome = (data) => window.dispatchEvent(new window.MessageEvent("message", { data, origin: CHROME_ORIGIN, source: window }));
+  const shadow = window.document.querySelector("[data-eh-ui]").shadowRoot;
+  return { window, document: window.document, posts, fromChrome, shadow };
+}
+
+const rows = (posts) => posts.filter((m) => m.type === "eh:edit").map(({ label, kind, before, after }) => ({ label, kind, before, after }));
+
+test("deleting a block reports it, offers undo, and undo restores it", { skip }, async () => {
+  const { document, posts, fromChrome, shadow } = await bootSdk("<h1>Plan</h1><p>Keep me.</p><p>Delete me.</p><p>Closing.</p>");
+  const target = document.querySelectorAll("p")[1];
+  target.dispatchEvent(new window.MouseEvent("mouseover", { bubbles: true }));
+  shadow.getElementById("chipDelete").click();
+
+  assert.equal(document.querySelectorAll("p").length, 2);
+  assert.deepEqual(rows(posts), [{ label: "Plan · p 2", kind: "deleted", before: "Delete me.", after: "" }]);
+  assert.ok(posts.some((m) => m.type === "eh:undoable" && m.kind === "deleted" && m.label === "Plan · p 2"));
+  assert.ok(posts.some((m) => m.type === "eh:html"), "the file is rewritten without the block");
+
+  fromChrome({ type: "eh:undo", label: "Plan · p 2", kind: "deleted" });
+  const texts = [...document.querySelectorAll("p")].map((p) => p.textContent);
+  assert.deepEqual(texts, ["Keep me.", "Delete me.", "Closing."], "the block is back where it was");
+});
+
+test("typing over a selection that spans blocks reports every block it touched", { skip }, async () => {
+  const { window, document, posts, fromChrome } = await bootSdk("<h2>Goals</h2><p>First goal paragraph.</p><p>Second goal paragraph.</p>");
+  const [first, second] = document.querySelectorAll("p");
+  const range = document.createRange();
+  range.setStart(first.firstChild, 6);
+  range.setEnd(second.firstChild, 7);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+
+  first.dispatchEvent(new window.Event("beforeinput", { bubbles: true }));
+  // What the browser does for a keystroke over that selection: the first
+  // block absorbs the remainder of the second, which disappears.
+  first.textContent = "First Xgoal paragraph.";
+  second.remove();
+  first.dispatchEvent(new window.Event("input", { bubbles: true }));
+  fromChrome({ type: "eh:flush" });
+
+  assert.deepEqual(rows(posts), [
+    { label: "Goals · p 1", kind: "edited", before: "First goal paragraph.", after: "First Xgoal paragraph." },
+    { label: "Goals · p 2", kind: "deleted", before: "Second goal paragraph.", after: "" },
+  ]);
+});
+
+test("labels number siblings by their order at load, so a deletion does not renumber the rest", { skip }, async () => {
+  const { document, posts, shadow } = await bootSdk("<h2>Goals</h2><p>One.</p><p>Two.</p><p>Three.</p>");
+  const paragraphs = document.querySelectorAll("p");
+  paragraphs[1].dispatchEvent(new window.MouseEvent("mouseover", { bubbles: true }));
+  shadow.getElementById("chipDelete").click();
+  paragraphs[2].dispatchEvent(new window.MouseEvent("mouseover", { bubbles: true }));
+  shadow.getElementById("chipDelete").click();
+  assert.deepEqual(
+    rows(posts).map((r) => r.label),
+    ["Goals · p 2", "Goals · p 3"],
+    "the third paragraph keeps its number after the second is gone"
+  );
+});

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { installSkills, invocation, isTransientBin } from "../src/setup.js";
+import { installSkills, invocation, isTransientBin, mergeAgentsBlock } from "../src/setup.js";
 
 test("global setup installs the skill for Claude Code, Codex, and shared agents", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-setup-"));
@@ -60,4 +60,58 @@ test("the CLI lookup hides its child process window", () => {
   });
 
   assert.equal(options?.windowsHide, true);
+});
+
+test("setup rewrites the AGENTS.md block it owns, replaces the legacy one, and leaves custom text alone", () => {
+  const block = "\n## Reviewing files and localhost pages with human-review\n\nNew instructions.\n";
+  const created = mergeAgentsBlock("", block);
+  assert.equal(created.action, "created");
+  assert.match(created.text, /^<!-- human-review:start -->\n## Reviewing/);
+  assert.match(created.text, /<!-- human-review:end -->\n$/);
+
+  // A second run with the same block changes nothing.
+  assert.equal(mergeAgentsBlock(created.text, block).action, "current");
+
+  // A newer block replaces the marked one and keeps everything around it.
+  const project = `# My project\n\nHouse rules.\n\n${created.text}\n## Testing\n\nRun npm test.\n`;
+  const updated = mergeAgentsBlock(project, "\n## Reviewing files and localhost pages with human-review\n\nNewer still.\n");
+  assert.equal(updated.action, "updated");
+  assert.match(updated.text, /House rules\./);
+  assert.match(updated.text, /Newer still\./);
+  assert.doesNotMatch(updated.text, /New instructions\./);
+  assert.match(updated.text, /## Testing\n\nRun npm test\./);
+  assert.equal((updated.text.match(/human-review:start/g) || []).length, 1);
+
+  // The block an older setup wrote had no markers: it ran from its heading to
+  // the next heading. It is replaced, not duplicated.
+  const legacy = "# My project\n\n## Reviewing files and localhost pages with human-review\n\nOld: poll with --timeout 600.\n\n## Testing\n\nRun npm test.\n";
+  const migrated = mergeAgentsBlock(legacy, block);
+  assert.equal(migrated.action, "updated");
+  assert.doesNotMatch(migrated.text, /--timeout 600/);
+  assert.match(migrated.text, /New instructions\./);
+  assert.match(migrated.text, /## Testing\n\nRun npm test\./);
+  assert.equal(mergeAgentsBlock(migrated.text, block).action, "current");
+
+  // A project that wrote its own human-review guidance keeps it.
+  const custom = "# Project\n\nWe use human-review our own way.\n";
+  assert.equal(mergeAgentsBlock(custom, block).action, "custom");
+  assert.equal(mergeAgentsBlock(custom, block).text, custom);
+});
+
+test("a project setup migrates a legacy AGENTS.md block on disk", () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-agents-"));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-home-"));
+  try {
+    fs.writeFileSync(path.join(cwd, "AGENTS.md"), "# P\n\n## Reviewing files and localhost pages with human-review\n\nThen block on poll --timeout 600.\n");
+    const first = installSkills(cwd, { home });
+    assert.ok(first.some((line) => line.startsWith("Updated AGENTS.md")), first.join("\n"));
+    const text = fs.readFileSync(path.join(cwd, "AGENTS.md"), "utf8");
+    assert.doesNotMatch(text, /--timeout 600/);
+    assert.match(text, /human-review:start/);
+    const second = installSkills(cwd, { home });
+    assert.ok(second.some((line) => line.startsWith("AGENTS.md already current")), second.join("\n"));
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  }
 });

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { installSkills, invocation, isNpxCachePath } from "../src/setup.js";
+import { installSkills, invocation, isTransientBin } from "../src/setup.js";
 
 test("global setup installs the skill for Claude Code, Codex, and shared agents", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-setup-"));
@@ -24,26 +24,32 @@ test("global setup installs the skill for Claude Code, Codex, and shared agents"
   }
 });
 
-test("a binary from npm's _npx cache does not count as installed on PATH", () => {
-  // `npx -y human-review setup --global` resolves `which human-review` to the
-  // transient cache copy, which disappears when npx exits. Writing a bare
-  // `human-review` into SKILL.md on the strength of that leaves every later
-  // agent run failing with "command not found".
-  assert.equal(
-    isNpxCachePath("/Users/x/.npm/_npx/f043fcd613c7efad/node_modules/.bin/human-review"),
-    true,
-  );
-  assert.equal(
-    isNpxCachePath("C:\\Users\\x\\AppData\\Local\\npm-cache\\_npx\\a1b2\\human-review.cmd"),
-    true,
-  );
+test("a bin that exists only for one command or one project is not an install", () => {
+  // npx: the package is on PATH for the length of the setup command only.
+  assert.equal(isTransientBin("/Users/x/.npm/_npx/f043fcd613c7efad/node_modules/.bin/human-review"), true);
+  assert.equal(isTransientBin("C:\\Users\\x\\AppData\\Local\\npm-cache\\_npx\\a1b2\\node_modules\\.bin\\human-review.cmd"), true);
 
-  // A real global install or `npm link` must still win.
-  assert.equal(isNpxCachePath("/opt/homebrew/bin/human-review"), false);
-  assert.equal(isNpxCachePath("/usr/local/bin/human-review"), false);
+  // pnpm dlx, yarn dlx, bunx, and a plain project-local dependency: durable on
+  // disk, but only resolvable from inside one project.
+  assert.equal(isTransientBin("/Users/x/project/node_modules/.bin/human-review"), true);
+  assert.equal(isTransientBin("/Users/x/.cache/bun/node_modules/.bin/human-review"), true);
 
-  // `_npx` only counts as a path segment, never as a substring of one.
-  assert.equal(isNpxCachePath("/Users/x/my_npx_tools/bin/human-review"), false);
+  // Durable installs must still win.
+  assert.equal(isTransientBin("/opt/homebrew/bin/human-review"), false);
+  assert.equal(isTransientBin("/usr/local/bin/human-review"), false);
+  assert.equal(isTransientBin("/Users/x/.volta/bin/human-review"), false);
+
+  // Both markers count only as whole path segments.
+  assert.equal(isTransientBin("/Users/x/my_npx_tools/bin/human-review"), false);
+  assert.equal(isTransientBin("/Users/x/node_modules_backup/bin/human-review"), false);
+});
+
+test("invocation prefers npx when the only bin on PATH is transient", () => {
+  const probe = (bin) => (_probe, _args) => ({ status: bin ? 0 : 1, stdout: bin ? `${bin}\n` : "" });
+  assert.equal(invocation(probe("/Users/x/.npm/_npx/deadbeef/node_modules/.bin/human-review")), "npx -y human-review");
+  assert.equal(invocation(probe("/Users/x/project/node_modules/.bin/human-review")), "npx -y human-review");
+  assert.equal(invocation(probe("/Users/x/.local/bin/human-review")), "human-review");
+  assert.equal(invocation(probe("")), "npx -y human-review");
 });
 
 test("the CLI lookup hides its child process window", () => {

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -25,6 +25,36 @@ test("openPage records the agent's version as the revert target", () => {
   assert.equal(store.pageForFile(file).key, opened.key);
 });
 
+test("the pristine copy lives in its own file, not in state.json, and a legacy inline copy migrates", () => {
+  const store = new Store();
+  const file = page("pristine.html", "<h1>big</h1>");
+  const big = `<h1>big</h1>${"<p>filler</p>".repeat(500)}`;
+  const { key } = store.openPage(file, big);
+  const stateFile = path.join(process.env.HUMAN_REVIEW_STATE_DIR, "state.json");
+  const raw = fs.readFileSync(stateFile, "utf8");
+  assert.doesNotMatch(raw, /filler/, "state.json no longer embeds whole documents");
+  const copy = path.join(process.env.HUMAN_REVIEW_STATE_DIR, "pristine", `${key}.html`);
+  assert.equal(fs.readFileSync(copy, "utf8"), big);
+  assert.equal(new Store().page(key).pristine, big, "a fresh store reads the copy back");
+
+  // An unchanged copy is not rewritten on every save.
+  const before = fs.statSync(copy).mtimeMs;
+  store.addComment(key, { id: "c1", kind: "selection", quote: "big", feedback: "x" });
+  assert.equal(fs.statSync(copy).mtimeMs, before);
+  store.setPristine(key, "<h1>v2</h1>");
+  assert.equal(fs.readFileSync(copy, "utf8"), "<h1>v2</h1>");
+
+  // A state.json written before this change still carries pristine inline.
+  const parsed = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+  parsed.pages[key].pristine = "<h1>inline</h1>";
+  fs.writeFileSync(stateFile, JSON.stringify(parsed));
+  const legacy = new Store();
+  assert.equal(legacy.page(key).pristine, "<h1>inline</h1>");
+  legacy.addComment(key, { id: "c2", kind: "selection", quote: "big", feedback: "y" });
+  assert.doesNotMatch(fs.readFileSync(stateFile, "utf8"), /inline/, "the next save moves it out");
+  assert.equal(fs.readFileSync(copy, "utf8"), "<h1>inline</h1>");
+});
+
 test("reopening a page keeps its comments", () => {
   const store = new Store();
   const file = page("b.html", "<h1>v1</h1>");

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -7,7 +7,7 @@ import path from "node:path";
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "human-review-test-"));
 process.env.HUMAN_REVIEW_STATE_DIR = path.join(tmp, "state");
 
-const { Store, resolveAsset } = await import("../src/state.js");
+const { Store, atomicWrite, resolveAsset } = await import("../src/state.js");
 const { canonicalTarget, localUrl, targetKey } = await import("../src/paths.js");
 
 function page(name, body) {
@@ -159,5 +159,238 @@ test(
     assert.equal(resolveAsset(file, "style.css"), fs.realpathSync(path.join(dir, "style.css")));
   }
 );
+
+/**
+ * atomicWrite's retry lives behind the fs calls it makes, not behind an
+ * exported seam, so these tests swap those calls out and drive the real
+ * two-argument entry point. Atomics.wait stands in for the backoff: sleepSync
+ * is the only thing that calls it.
+ */
+const realRename = fs.renameSync;
+const realUnlink = fs.unlinkSync;
+const realWait = Atomics.wait;
+
+function withPatchedFs({ rename, unlink, wait }, fn) {
+  if (rename) fs.renameSync = rename;
+  if (unlink) fs.unlinkSync = unlink;
+  if (wait) Atomics.wait = wait;
+  try {
+    return fn();
+  } finally {
+    fs.renameSync = realRename;
+    fs.unlinkSync = realUnlink;
+    Atomics.wait = realWait;
+  }
+}
+
+const fail = (code) => {
+  const err = new Error(code + ": simulated");
+  err.code = code;
+  return err;
+};
+
+/** A rename that fails with `code` its first `times` calls, then succeeds. */
+function flakyRename(code, times) {
+  const calls = { count: 0 };
+  return {
+    calls,
+    rename: (from, to) => {
+      if (++calls.count <= times) throw fail(code);
+      return realRename(from, to);
+    },
+  };
+}
+
+/** Records the backoff without actually waiting, so the suite stays fast. */
+function recordWaits(slept) {
+  return (...args) => {
+    slept.push(args[3]);
+    return "timed-out";
+  };
+}
+
+const orphans = (dir) => fs.readdirSync(dir).filter((n) => n.endsWith(".human-review.tmp"));
+const scratch = (name) => fs.mkdtempSync(path.join(tmp, name));
+
+function capture(fn) {
+  try {
+    fn();
+  } catch (err) {
+    return err;
+  }
+  return undefined;
+}
+
+for (const code of ["EPERM", "EACCES", "EBUSY"]) {
+  test("atomicWrite retries a " + code + " rename, which Windows scanners cause", () => {
+    const dir = scratch("retry-");
+    const file = path.join(dir, "state.json");
+    const { calls, rename } = flakyRename(code, 2);
+    const slept = [];
+
+    withPatchedFs({ rename, wait: recordWaits(slept) }, () => atomicWrite(file, "payload"));
+
+    assert.equal(fs.readFileSync(file, "utf8"), "payload");
+    assert.equal(calls.count, 3, "two failures then a success");
+    assert.deepEqual(slept, [1, 2], "backs off between attempts");
+    assert.deepEqual(orphans(dir), [], "no tmp file left behind");
+  });
+}
+
+test("atomicWrite gives up after a bounded number of retries", () => {
+  const dir = scratch("give-up-");
+  const file = path.join(dir, "state.json");
+  const { calls, rename } = flakyRename("EPERM", Infinity);
+  const slept = [];
+
+  const thrown = withPatchedFs({ rename, wait: recordWaits(slept) }, () =>
+    capture(() => atomicWrite(file, "payload"))
+  );
+
+  assert.equal(thrown?.code, "EPERM", "a truly stuck file still surfaces its error");
+  assert.equal(calls.count, 5, "bounded");
+  assert.deepEqual(slept, [1, 2, 4, 8], "no wait after the final attempt");
+  assert.equal(fs.existsSync(file), false);
+  assert.deepEqual(orphans(dir), [], "cleans up even when every attempt fails");
+});
+
+test("atomicWrite never retries an error that a retry cannot fix", () => {
+  const dir = scratch("fatal-");
+  const file = path.join(dir, "state.json");
+  const { calls, rename } = flakyRename("ENOSPC", Infinity);
+  const slept = [];
+
+  const thrown = withPatchedFs({ rename, wait: recordWaits(slept) }, () =>
+    capture(() => atomicWrite(file, "payload"))
+  );
+
+  assert.equal(thrown?.code, "ENOSPC");
+  assert.equal(calls.count, 1, "fails fast");
+  assert.deepEqual(slept, []);
+  assert.deepEqual(orphans(dir), []);
+});
+
+test("atomicWrite clears the temp file even when the unlink is blocked too", () => {
+  const dir = scratch("unlink-blocked-");
+  const file = path.join(dir, "state.json");
+  const { rename } = flakyRename("EPERM", Infinity);
+  const slept = [];
+
+  // The handle that blocks the rename blocks the unlink for just as long.
+  let unlinkCalls = 0;
+  const unlink = (target) => {
+    if (++unlinkCalls <= 2) throw fail("EPERM");
+    return realUnlink(target);
+  };
+
+  const thrown = withPatchedFs({ rename, unlink, wait: recordWaits(slept) }, () =>
+    capture(() => atomicWrite(file, "payload"))
+  );
+
+  assert.equal(thrown?.code, "EPERM");
+  assert.equal(unlinkCalls, 3, "keeps trying while the handle is held");
+  assert.deepEqual(orphans(dir), [], "nothing stranded in the state directory");
+  // The first four waits are the rename retries; the rest is cleanup backing
+  // off, so dropping that sleep would fail here.
+  assert.deepEqual(slept, [1, 2, 4, 8, 1, 2], "cleanup backs off as well");
+});
+
+test("cleanup exhaustion is bounded the same way the rename retry is", () => {
+  const dir = scratch("unlink-stuck-");
+  const file = path.join(dir, "state.json");
+  const { rename } = flakyRename("EPERM", Infinity);
+  const slept = [];
+
+  const cleanupFailure = fail("EPERM");
+  let unlinkCalls = 0;
+  const unlink = () => {
+    unlinkCalls++;
+    throw cleanupFailure;
+  };
+
+  const thrown = withPatchedFs({ rename, unlink, wait: recordWaits(slept) }, () =>
+    capture(() => atomicWrite(file, "payload"))
+  );
+
+  // Both errors carry EPERM, so only identity can tell them apart.
+  assert.ok(thrown, "the write failure has to reach the caller");
+  assert.notEqual(thrown, cleanupFailure, "the write error survives, not the cleanup error");
+  assert.equal(unlinkCalls, 5, "cleanup gives up after the same number of attempts");
+  assert.deepEqual(slept, [1, 2, 4, 8, 1, 2, 4, 8], "no wait after the final attempt");
+});
+
+test("a sleep that throws mid-retry cannot hijack the rename error", () => {
+  const dir = scratch("retry-sleep-throws-");
+  const file = path.join(dir, "state.json");
+  const { rename } = flakyRename("EPERM", Infinity);
+  const sleepFailure = new Error("sleep exploded");
+
+  // The very first wait belongs to the retry loop, so this covers the retry
+  // phase; the cleanup phase is covered below.
+  const thrown = withPatchedFs(
+    {
+      rename,
+      wait: () => {
+        throw sleepFailure;
+      },
+    },
+    () => capture(() => atomicWrite(file, "payload"))
+  );
+
+  assert.ok(thrown, "the write failure has to reach the caller");
+  assert.notEqual(thrown, sleepFailure, "a broken sleeper must not become the reported error");
+  assert.equal(thrown.code, "EPERM");
+  assert.deepEqual(orphans(dir), []);
+});
+
+test("a sleep that throws during cleanup cannot hijack the write error either", () => {
+  const dir = scratch("cleanup-sleep-throws-");
+  const file = path.join(dir, "state.json");
+  const { rename } = flakyRename("EPERM", Infinity);
+  const sleepFailure = new Error("sleep exploded");
+
+  // Cleanup is the only phase that calls unlink, so that marks the boundary.
+  let inCleanup = false;
+  const unlink = () => {
+    inCleanup = true;
+    throw fail("EPERM");
+  };
+
+  const thrown = withPatchedFs(
+    {
+      rename,
+      unlink,
+      wait: () => {
+        if (inCleanup) throw sleepFailure;
+        return "timed-out";
+      },
+    },
+    () => capture(() => atomicWrite(file, "payload"))
+  );
+
+  assert.ok(inCleanup, "the test has to actually reach the cleanup path");
+  assert.ok(thrown, "the write failure has to reach the caller");
+  assert.notEqual(thrown, sleepFailure, "a broken sleeper must not become the reported error");
+  assert.equal(thrown.code, "EPERM");
+});
+
+test("the backoff really sleeps, on Node's main thread", () => {
+  const dir = scratch("real-sleep-");
+  const file = path.join(dir, "state.json");
+  const { calls, rename } = flakyRename("EPERM", 3);
+
+  // Atomics.wait is left alone here, so this runs the real sleeper. Spying on
+  // it would prove it was called but not that it waited; elapsed time is the
+  // part a no-op cannot fake.
+  const started = process.hrtime.bigint();
+  withPatchedFs({ rename }, () => atomicWrite(file, "payload"));
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+
+  assert.equal(fs.readFileSync(file, "utf8"), "payload");
+  assert.equal(calls.count, 4);
+  // Waits total 1 + 2 + 4 = 7ms; allow a little timer granularity, but stay
+  // far above the ~0ms a no-op or throwing sleeper would take.
+  assert.ok(elapsedMs >= 6, "expected a real delay, waited " + elapsedMs.toFixed(2) + "ms");
+});
 
 test.after(() => fs.rmSync(tmp, { recursive: true, force: true }));

--- a/test/url-review.test.js
+++ b/test/url-review.test.js
@@ -74,7 +74,7 @@ test("a localhost route is visually editable and returns source-directed feedbac
     body: { target },
   });
   assert.equal(opened.status, 200, opened.raw);
-  const { key, sessionId } = JSON.parse(opened.raw);
+  const { key, sessionId, artifactToken } = JSON.parse(opened.raw);
 
   const state = await request(review.port, review.token, { route: `/api/page/${key}` });
   const page = JSON.parse(state.raw);
@@ -84,7 +84,7 @@ test("a localhost route is visually editable and returns source-directed feedbac
   assert.equal(page.feedbackOnly, true);
   assert.equal(page.canRevert, false);
 
-  const artifact = await request(review.port, review.token, { route: `/artifact/${key}/index.html` });
+  const artifact = await request(review.port, review.token, { route: `/artifact/${artifactToken}/${key}/index.html` });
   assert.equal(artifact.status, 200, artifact.raw);
   assert.match(artifact.raw, /<h1>Wiki<\/h1>/);
   assert.doesNotMatch(artifact.raw, /<base/);


### PR DESCRIPTION
## Summary

Builds on the background-poll change so every wait terminates cleanly, then lands the top items from the audit and the community PRs. One branch, phased commits.

### The wait (why #42 exists)
- The agent starts one `human-review poll <target>` in the background and ends its turn. The command exits only on Send, End review, tab close, or when no review is open — never on a timer. An open-ended wait reconnects across server restarts and caps itself at 12 hours.
- Closing the tab ends the review after a short grace (a reload comes back in time); a tab that silently vanishes ends it after 30 minutes; a session no browser ever connected to is dropped after a minute. Every path releases the poll with `status: closed`, a `reason`, and the unsent counts, and the skill tells the agent to report those in one line.
- A newer poll for the same target supersedes an older one, so stale waits cannot double-apply.

### Batch delivery
- `delivered` is persisted, so a server replaced between delivery and `--ack` honors the ack instead of re-shipping. A batch written by an overlapping server is read from disk.
- Sending while the agent is applying a batch queues only the new items; the agent's next `--ack` clears both. The UI shows "queued" rather than "nobody is listening".
- Per page: `edits_saved` and `markdown` flags. Edit text is capped at 200k with an explicit `truncated` marker instead of a silent 4k cut. Markdown and self-rendering pages keep unsent edit rows when the file changes on disk.
- Rewording a comment updates an undelivered batch in place, or takes a fresh id after delivery so the rewrite ships next time.

### Hardening
- One server per state directory: lock file plus health-checked takeover of an older-protocol server. Protocol 9.
- Artifact URLs carry a per-run secret; a path-derived key is no longer enough to read sibling files.
- Localhost reviews proxy the app's own requests (API calls, prefetches, `srcset`) to the app origin. `srcset` is absolutized too.

### Editor
- Undo for block delete and move (toast with an Undo button).
- Leftover feedback from a review that ended without a Send gets a Keep/Discard banner on the next open, noting that HTML text edits are already in the file.
- Typing over a selection that spans blocks reports every block, including a deleted row for one that vanished; a paragraph turned into a list keeps its label and original; label ordinals follow load order so a deletion doesn't renumber siblings.
- Comments get an Edit button and an edited badge.
- The tab re-opens its session after a long sleep instead of becoming a dead tab that looks alive.

### Community
- Merged: #40 (@rzilem, Windows rename retry), #37 (@dacoldest, sandbox + href guard), #30 (@ulysses0604, IME Enter), #36 (@NuclearManatee, tab title), #7 (@noammigdali-hio, transient bin detection, ported onto the current signature).
- Fixed issues #12 (comment textarea caret), #25 (details/summary), #26 (heading label).

### SKILL.md
- closed/superseded handling, `edits_saved`, `deleted` and `truncated` rows, quotes are rendered text with `anchor` context, copy staged assets before ack, note-only batches. Codex block matches.

## Test plan
- [x] `npm test` — 117 passing; new `test/lifecycle.test.js` covers tab close, reload grace, no-review grace, supersede, queued sends, delivery across restart, truncation, external writes, undo/discard, rewording, `edits_saved`, artifact secret, and the localhost proxy
- [x] Real Chrome: closing the review tab released a background `poll` with `reason: window_closed`; Undo toast removed the row; leftover banner shows the right counts; no console errors

### Production cleanup (added)
- `setup` now owns the AGENTS.md block with marker comments and rewrites it on every run, replacing the unmarked block older setups wrote. Projects set up months ago pick up current instructions instead of keeping stale ones forever.
- Each page's pristine copy lives in `pristine/<key>.html` instead of inside state.json, written only when it changes. Edit flushes no longer rewrite whole documents.
- Editor smoke tests under jsdom (delete + undo, multi-block typing, stable labels), which caught one more labeling bug.
- Version 0.7.0.
- Tests: 123 passing.