### PR TITLE
README: agent wake-up wording; Discard reverts an autosaved HTML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Review a page running on localhost:
 
 Human Review opens the file in your browser. Make direct edits, leave comments, and click Send. Your agent receives all your feedback in one batch, updates the source, and refreshes the page for another review.
 
-The agent waits with a single background command that exits the moment you hit Send — no polling on a timer. Closing the tab, or clicking End review, releases the agent too. Feedback you never sent is kept, and the next time you open that page you can restore or discard it.
+In Claude Code, the agent waits in the background and picks up your feedback the moment you hit Send. In Codex and other agents, it waits during its turn; if the turn already ended, send a message and it picks the feedback up. Closing the tab or clicking End review releases the agent either way. Feedback you never sent is kept, and the next time you open that page you can restore or discard it.
 
-Note: For HTML files, direct edits and resizes save automatically. For Markdown and localhost pages, click Send so your agent can apply them to the source.
+Note: For HTML files, direct edits and resizes save automatically, so closing the tab doesn't undo them — Discard on your next open, or Revert all during the review, puts the file back. For Markdown and localhost pages, click Send so your agent can apply them to the source.
 
 ## What this skill lets you do
 

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -392,7 +392,7 @@ function render() {
     const parts = [];
     if (leftover.comments) parts.push(`${leftover.comments} ${leftover.comments === 1 ? "comment" : "comments"}`);
     if (leftover.edits) parts.push(`${leftover.edits} ${leftover.edits === 1 ? "edit" : "edits"}`);
-    const savedNote = page.kind === "file" && !page.markdown ? " Text edits are already in the file either way." : "";
+    const savedNote = page.kind === "file" && !page.markdown ? " Text edits are already in the file; Discard puts the agent's version back." : "";
     $("leftoverText").textContent = `${parts.join(" and ")} from your last review never went to the agent.${savedNote}`;
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -312,7 +312,23 @@ export function createServer() {
     const clean = stripSdk(html);
     atomicWrite(page.file, clean);
     lastWritten.set(key, hash(clean));
+    store.setSavedHash(key, hash(clean));
     return clean;
+  }
+
+  /**
+   * Register a file for review. The file as it sits on disk becomes the
+   * agent's version — the revert target — unless the page still carries
+   * unsent edits and the file is exactly what the browser last autosaved:
+   * then the disk copy *is* those edits, and the agent's version stays.
+   */
+  function openFile(file) {
+    const html = stripSdk(fs.readFileSync(file, "utf8"));
+    const existing = store.pageForFile(file);
+    const keep = !!existing && existing.kind !== "url" && existing.edits.length > 0 && existing.savedHash === hash(html);
+    const page = store.openPage(file, keep ? undefined : html);
+    lastWritten.set(page.key, hash(html));
+    return page;
   }
 
   // ------------------------------------------------------------------ batch
@@ -735,9 +751,7 @@ export function createServer() {
           page = store.openUrl(target.value);
         } else {
           if (!fs.existsSync(target.value)) return json(res, 404, { error: `File not found: ${target.value}` });
-          const html = fs.readFileSync(target.value, "utf8");
-          page = store.openPage(target.value, stripSdk(html));
-          lastWritten.set(page.key, hash(stripSdk(html)));
+          page = openFile(target.value);
         }
         watchPage(page.key);
         const id = uid("s");
@@ -1154,9 +1168,7 @@ export function createServer() {
         if (!targetFile || !fs.existsSync(targetFile) || !/\.(x?html?|md|markdown)$/i.test(targetFile)) {
           return json(res, 400, { error: "not a local html or markdown page" });
         }
-        const html = fs.readFileSync(targetFile, "utf8");
-        const page = store.openPage(targetFile, stripSdk(html));
-        lastWritten.set(page.key, hash(stripSdk(html)));
+        const page = openFile(targetFile);
         watchPage(page.key);
         session.activeKey = page.key;
         session.visited.add(page.key);

--- a/src/server.js
+++ b/src/server.js
@@ -994,9 +994,14 @@ export function createServer() {
 
         // Leftover feedback from an earlier review the user chose not to keep.
         if (action === "discard" && req.method === "POST") {
+          const page = store.page(key);
+          // On a plain HTML file the edits were autosaved into it; discarding
+          // them means putting the agent's version back, not just dropping rows.
+          const reverted = page.kind !== "url" && !isMarkdown(page.file) && !page.dynamic && !!page.pristine;
+          if (reverted) writePage(key, page.pristine);
           store.discardFeedback(key);
-          for (const session of sessionsForKey(key)) emit(session, "refresh", {});
-          return json(res, 200, { page: pageState(key) });
+          for (const session of sessionsForKey(key)) emit(session, reverted ? "reload" : "refresh", reverted ? { key } : {});
+          return json(res, 200, { page: pageState(key), reverted });
         }
 
         // File reviews keep pasted images beside the document. Localhost

--- a/src/state.js
+++ b/src/state.js
@@ -331,6 +331,15 @@ export class Store {
     return found ? page : null;
   }
 
+  /** What human-review itself last wrote to the file, so a later open can tell the user's autosave from someone else's write. */
+  setSavedHash(key, savedHash) {
+    const page = this.page(key);
+    if (!page || page.savedHash === savedHash) return page;
+    return this.update(key, (p) => {
+      p.savedHash = savedHash;
+    });
+  }
+
   /** Undo of a delete or move: the row for that block no longer describes anything. */
   removeEdit(key, label, kind) {
     return this.update(key, (page) => {

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -295,12 +295,25 @@ test("undo removes the edit row; discard clears leftover feedback", async (t) =>
   assert.deepEqual(page.edits.map((e) => e.label), ["p 2"]);
   await comment(port, token, opened.key, "Beta", "Old thought");
 
-  // A later open reports what was left behind, and discard wipes it.
+  // A later open reports what was left behind, and discard wipes it — and on
+  // an HTML file, whose edits were autosaved, restores the agent's version.
+  // The browser autosaves through the save route, so the file changes while
+  // the agent's version stays the revert target.
+  const raw = j(await request(port, token, { route: `/api/page/${opened.key}/raw` }));
+  await request(port, token, {
+    method: "POST",
+    route: `/api/page/${opened.key}/save`,
+    body: { html: "<!DOCTYPE html>\n<html><head></head><body><p>Gamma</p></body></html>\n", baseHash: raw.hash },
+  });
+  assert.match(fs.readFileSync(file, "utf8"), /Gamma/);
   const reopened = await open(port, token, file);
   assert.deepEqual(reopened.leftover, { comments: 1, edits: 1 });
-  page = j(await request(port, token, { method: "POST", route: `/api/page/${opened.key}/discard` })).page;
+  const discarded = j(await request(port, token, { method: "POST", route: `/api/page/${opened.key}/discard` }));
+  page = discarded.page;
   assert.deepEqual(page.comments, []);
   assert.deepEqual(page.edits, []);
+  assert.equal(discarded.reverted, true);
+  assert.match(fs.readFileSync(file, "utf8"), /<p>Alpha<\/p>/, "the file is back to the agent's version");
   const fresh = await open(port, token, file);
   assert.deepEqual(fresh.leftover, { comments: 0, edits: 0 });
 });


### PR DESCRIPTION
## Summary
- README says plainly that Claude Code wakes the agent on Send, while Codex and other agents wait during their turn and need a message after an ended turn. It also notes that HTML edits autosave, so closing the tab doesn't undo them.
- Discard on the leftover-feedback banner now restores the agent's version of a plain HTML file, not just the feedback rows. Markdown, localhost, and self-rendering pages are unchanged since their edits were never on disk. The response carries `reverted` and the page reloads.

## Test plan
- [x] `npm test` — 123 passing; the discard test now autosaves through the save route and asserts the file is restored