### PR TITLE
Open the compose card for keyboard selections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "human-review",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "human-review",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "marked": "^18.0.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "human-review",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Review and edit agent-generated files and localhost pages in the browser, then send the whole batch back to your agent.",
   "author": "Peter Yang",
   "homepage": "https://github.com/petergyang/human-review#readme",

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -754,6 +754,26 @@ function boot() {
     }, 0);
   });
 
+  // A selection made with the keyboard (Shift+arrows, Shift+Home/End) never
+  // produces a mouseup, so settle it when the key is released instead. The
+  // wait lets a selection being extended settle once, not on every keystroke.
+  let keySelectTimer = null;
+  document.addEventListener(
+    "keyup",
+    (event) => {
+      if (isOurs(event.target) || resizing || moving || linkState) return;
+      const extending = event.shiftKey && /^(Arrow(Left|Right|Up|Down)|Home|End|PageUp|PageDown)$/.test(event.key);
+      const selectAll = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "a";
+      if (event.key !== "Shift" && !extending && !selectAll) return;
+      clearTimeout(keySelectTimer);
+      keySelectTimer = setTimeout(() => {
+        if (Date.now() < suppressUntil || composeOpen) return;
+        settleSelection();
+      }, 250);
+    },
+    true
+  );
+
   document.addEventListener(
     "click",
     (event) => {

--- a/test/sdk.test.js
+++ b/test/sdk.test.js
@@ -97,6 +97,24 @@ test("typing over a selection that spans blocks reports every block it touched",
   ]);
 });
 
+test("a keyboard selection opens the compose card when the key is released", { skip }, async () => {
+  const { window, document, posts } = await bootSdk("<h1>Plan</h1><p>Select these words with the keyboard.</p>");
+  const p = document.querySelector("p");
+  const range = document.createRange();
+  range.setStart(p.firstChild, 7);
+  range.setEnd(p.firstChild, 12);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+  p.dispatchEvent(new window.KeyboardEvent("keyup", { key: "ArrowRight", shiftKey: true, bubbles: true }));
+  p.dispatchEvent(new window.KeyboardEvent("keyup", { key: "Shift", bubbles: true }));
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  const compose = posts.filter((m) => m.type === "eh:compose");
+  assert.equal(compose.length, 1, "one card for the settled selection, not one per keystroke");
+  assert.equal(compose[0].kind, "selection");
+  assert.equal(compose[0].quote, "these");
+});
+
 test("labels number siblings by their order at load, so a deletion does not renumber the rest", { skip }, async () => {
   const { document, posts, shadow } = await bootSdk("<h2>Goals</h2><p>One.</p><p>Two.</p><p>Three.</p>");
   const paragraphs = document.querySelectorAll("p");


### PR DESCRIPTION
## Summary
The comment card only opened on mouseup, so text selected with Shift+arrows or Shift+Home/End never offered a comment. Key release now settles the selection after a short pause, once per selection rather than once per keystroke. Bumps to 0.7.1.

## Test plan
- [x] jsdom test: a Shift+Arrow selection posts one compose message with the right quote
- [x] Verified in Chrome against the built SDK: a keyboard selection opens one card with the quote and anchor context
- [x] `npm test` — 124 passing