### PR TITLE
Clearer drop target, auto-scroll, and undo for every delete and move

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "human-review",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "human-review",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "marked": "^18.0.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "human-review",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Review and edit agent-generated files and localhost pages in the browser, then send the whole batch back to your agent.",
   "author": "Peter Yang",
   "homepage": "https://github.com/petergyang/human-review#readme",

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -294,6 +294,18 @@ function render() {
       kind.className = "kind";
       kind.textContent = edit.kind;
       row.append(pip, label, kind);
+      if (edit.kind === "deleted" || edit.kind === "moved") {
+        const undo = document.createElement("button");
+        undo.type = "button";
+        undo.className = "row-undo";
+        undo.textContent = "Undo";
+        undo.title = edit.kind === "moved" ? "Put this block back where it was" : "Restore this block";
+        undo.addEventListener("click", (event) => {
+          event.stopPropagation();
+          undoBlock(edit.label, edit.kind);
+        });
+        row.append(undo);
+      }
       rows.append(row);
     }
     if (edits.length > LIMIT) {
@@ -507,8 +519,12 @@ function toast(message, { action = "", onAction = null, ms = 3200 } = {}) {
  */
 let editChain = Promise.resolve();
 
+/** Ask the editor to put the block back; the row is dropped once it confirms (eh:undone). */
 function undoBlock(label, kind) {
   toFrame({ type: "eh:undo", label, kind });
+}
+
+function dropEditRow(label, kind) {
   editChain = editChain.then(async () => {
     try {
       state.page = (await api(`/api/page/${state.key}/edit`, { method: "DELETE", body: JSON.stringify({ label, kind }) })).page;
@@ -678,11 +694,18 @@ window.addEventListener("message", async (event) => {
       await editChain.catch((err) => toast(err.message));
       break;
     case "eh:undoable":
-      toast(msg.kind === "moved" ? `Moved “${tidy(msg.label, 40)}”` : `Deleted “${tidy(msg.label, 40)}”`, {
+      toast(msg.kind === "moved" ? `Moved “${tidy(msg.label, 40)}” — ⌘Z or Undo to put it back` : `Deleted “${tidy(msg.label, 40)}” — ⌘Z or Undo to restore`, {
         action: "Undo",
         ms: 8000,
         onAction: () => undoBlock(msg.label, msg.kind),
       });
+      break;
+    case "eh:undone":
+      document.querySelectorAll(".toast").forEach((el) => el.remove());
+      dropEditRow(String(msg.label || ""), String(msg.kind || ""));
+      break;
+    case "eh:undoFailed":
+      toast(msg.kind === "moved" ? "Can't put that one back after a reload — drag it where you want it" : "Can't restore that one after a reload");
       break;
     case "eh:asset":
       try {

--- a/src/chrome.css
+++ b/src/chrome.css
@@ -484,3 +484,17 @@ body.collapsed .handle { right: 0; }
 .leftover-actions .btn-ghost { padding: 4px 10px; font-size: 12px; }
 
 .edit-comment { margin-left: 0; }
+
+/* Per-row undo for the two gestures with no native undo. */
+.edit-row .row-undo {
+  flex: none;
+  margin-left: 6px;
+  padding: 1px 7px;
+  border: 1px solid var(--hair);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--mute-2);
+  font-size: 11px;
+  cursor: pointer;
+}
+.edit-row .row-undo:hover { background: var(--soft); color: var(--strong-txt); border-color: var(--strong-border); }

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -1494,6 +1494,10 @@ function boot() {
     const target = targetFor(el);
     moving = { el, label: target ? target.label : "Block", drop: null, pointer: { x: event.clientX, y: event.clientY } };
     captureOriginal(moving.el);
+    // Dimming the block is our doing, not the page rendering itself: say so
+    // before touching it, or a move as the first action reads as self-render
+    // and switches saves off for the rest of the review.
+    userEdited = true;
     moving.el.style.opacity = "0.4";
     place(els.outline, null);
     showChip(null);

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -100,9 +100,25 @@ shadow.innerHTML = `
     .mover:hover { color: #1b1a16; border-color: #c2beb4; }
     .mover:active { cursor: grabbing; }
     .dropline {
-      position: fixed; z-index: 2147483646; height: 0; display: none;
-      border-top: 2px solid #1b1a16; border-radius: 1px; pointer-events: none;
+      position: fixed; z-index: 2147483646; height: 3px; display: none;
+      background: #1f6feb; border-radius: 2px; pointer-events: none;
+      box-shadow: 0 0 0 2px rgba(255,255,255,.9);
     }
+    .dropline::before, .dropline::after {
+      content: ""; position: absolute; top: -3px; width: 9px; height: 9px;
+      border-radius: 50%; background: #1f6feb; box-shadow: 0 0 0 2px rgba(255,255,255,.9);
+    }
+    .dropline::before { left: -4px; }
+    .dropline::after { right: -4px; }
+    .dropTarget { border: 1px dashed #1f6feb; background: rgba(31,111,235,.05); }
+    .dragLabel {
+      position: fixed; z-index: 2147483647; display: none; max-width: 360px; padding: 4px 9px;
+      border-radius: 6px; background: #1b1a16; color: #fbfaf7; white-space: nowrap;
+      overflow: hidden; text-overflow: ellipsis; pointer-events: none;
+      font: 11.5px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      box-shadow: 0 4px 14px rgba(27,26,22,.22);
+    }
+    .dragLabel b { color: #9cc2ff; font-weight: 600; }
   </style>
   <div class="box outline" id="outline"></div>
   <div class="box active" id="activeBox"></div>
@@ -117,7 +133,9 @@ shadow.innerHTML = `
     <button class="chip danger" id="linkRemove" title="Remove link" aria-label="Remove link">&#10005;</button>
   </div>
   <div class="mover" id="mover" title="Drag to move this block">&#10303;</div>
+  <div class="box dropTarget" id="dropTarget"></div>
   <div class="dropline" id="dropline"></div>
+  <div class="dragLabel" id="dragLabel"></div>
 `;
 
 const els = {};
@@ -135,6 +153,8 @@ const mountOverlay = () => {
   els.linkRemove = shadow.getElementById("linkRemove");
   els.mover = shadow.getElementById("mover");
   els.dropline = shadow.getElementById("dropline");
+  els.dropTarget = shadow.getElementById("dropTarget");
+  els.dragLabel = shadow.getElementById("dragLabel");
 };
 
 function showMover(el) {
@@ -154,16 +174,35 @@ function showMover(el) {
   els.mover.style.top = `${Math.max(4, r.top + 1)}px`;
 }
 
-function showDropline(drop) {
+/**
+ * Where a dragged block will land: a bold line on the edge it drops against,
+ * a dashed outline on the block that edge belongs to, and a label by the
+ * pointer saying the same in words. Three cues, because a thin line alone
+ * vanishes against borders and bullets.
+ */
+function showDropline(drop, pointer, movingLabel) {
   if (!drop || !drop.ref.isConnected) {
     els.dropline.style.display = "none";
+    els.dropTarget.style.display = "none";
+    els.dragLabel.style.display = "none";
     return;
   }
   const r = drop.ref.getBoundingClientRect();
   els.dropline.style.display = "block";
   els.dropline.style.left = `${r.left}px`;
   els.dropline.style.width = `${r.width}px`;
-  els.dropline.style.top = `${(drop.before ? r.top : r.bottom) - 1}px`;
+  els.dropline.style.top = `${(drop.before ? r.top : r.bottom) - 2}px`;
+  place(els.dropTarget, drop.ref, 3);
+  if (!pointer) return;
+  els.dragLabel.textContent = "";
+  const verb = document.createTextNode(`Move “${clip(movingLabel, 28)}” ${drop.before ? "above" : "below"} `);
+  const target = document.createElement("b");
+  target.textContent = `“${clip(drop.ref.textContent, 32)}”`;
+  els.dragLabel.append(verb, target);
+  els.dragLabel.style.display = "block";
+  const below = pointer.y + 44 < window.innerHeight;
+  els.dragLabel.style.left = `${Math.max(8, Math.min(pointer.x + 14, window.innerWidth - 372))}px`;
+  els.dragLabel.style.top = `${below ? pointer.y + 18 : pointer.y - 34}px`;
 }
 
 function place(box, el, pad = 2) {
@@ -906,7 +945,18 @@ function boot() {
    * Delete and move are the two gestures with no native undo, so the last
    * one is kept restorable: the element itself, detached, plus where it was.
    */
-  let undoable = null; // { kind, el, parent, next, label }
+  /**
+   * Every delete and move stays restorable for the life of the page: the
+   * element itself, detached or relocated, plus where it came from. The
+   * chrome's per-row Undo and ⌘Z both come here.
+   */
+  const undoStack = []; // [{ kind, el, parent, next, label, at }]
+  const remember = (entry) => {
+    undoStack.push({ ...entry, at: Date.now() });
+    if (undoStack.length > 50) undoStack.shift();
+  };
+  /** Timestamp of the last keystroke, so ⌘Z after typing stays the browser's own undo. */
+  let lastInputAt = 0;
 
   els.chipDelete.addEventListener("click", (event) => {
     event.preventDefault();
@@ -916,7 +966,7 @@ function boot() {
     const target = targetFor(hoverTarget);
     const label = target ? target.label : "Element";
     const before = hoverTarget.textContent;
-    undoable = { kind: "deleted", el: hoverTarget, parent: hoverTarget.parentNode, next: hoverTarget.nextSibling, label };
+    remember({ kind: "deleted", el: hoverTarget, parent: hoverTarget.parentNode, prev: hoverTarget.previousSibling, next: hoverTarget.nextSibling, label });
     hoverTarget.remove();
     hoverTarget = null;
     place(els.outline, null);
@@ -927,16 +977,31 @@ function boot() {
   });
 
   const restoreBlock = (label, kind) => {
-    const undo = undoable;
-    undoable = null;
-    if (!undo || undo.label !== label || undo.kind !== kind) return;
-    if (!undo.parent || !undo.parent.isConnected) return;
+    let index = -1;
+    for (let i = undoStack.length - 1; i >= 0; i -= 1) {
+      if (undoStack[i].label === label && undoStack[i].kind === kind) {
+        index = i;
+        break;
+      }
+    }
+    const undo = index === -1 ? null : undoStack[index];
+    if (!undo || !undo.parent || !undo.parent.isConnected) {
+      // Nothing to put back: the page reloaded since, or the spot is gone.
+      post("eh:undoFailed", { label, kind });
+      return false;
+    }
+    undoStack.splice(index, 1);
+    // Either neighbor may have been deleted or moved since; use whichever is
+    // still in place, and only fall back to the end when both are gone.
     const next = undo.next && undo.next.parentNode === undo.parent ? undo.next : null;
-    undo.parent.insertBefore(undo.el, next);
+    const prev = undo.prev && undo.prev.parentNode === undo.parent ? undo.prev : null;
+    undo.parent.insertBefore(undo.el, next || (prev ? prev.nextSibling : null));
     undo.el.style.opacity = "";
-    // The chrome drops the row; the block is back to its captured original,
-    // so there is nothing new to report — only the file to write again.
+    // The chrome drops the row on eh:undone; the block is back to its captured
+    // original, so there is nothing new to report — only the file to write again.
     flushSave();
+    post("eh:undone", { label, kind });
+    return true;
   };
 
   // beforeinput still sees the untouched wording, so capture it once per block.
@@ -1221,6 +1286,18 @@ function boot() {
       const sel = document.getSelection();
       const anchor = sel ? sel.anchorNode : null;
 
+      // ⌘Z right after a block delete or move undoes that, not the last
+      // keystroke — unless typing came after it, which stays the browser's undo.
+      if (meta && !event.shiftKey && !event.altKey && (event.key === "z" || event.key === "Z")) {
+        const last = undoStack[undoStack.length - 1];
+        if (last && last.at > lastInputAt) {
+          event.preventDefault();
+          event.stopPropagation();
+          restoreBlock(last.label, last.kind);
+        }
+        return;
+      }
+
       // ⌘K links the selection, like Docs, Word, and Notion.
       if (meta && !event.shiftKey && !event.altKey && (event.key === "k" || event.key === "K")) {
         if (openLinkbox()) {
@@ -1415,11 +1492,12 @@ function boot() {
     event.preventDefault();
     event.stopPropagation();
     const target = targetFor(el);
-    moving = { el, label: target ? target.label : "Block", drop: null };
+    moving = { el, label: target ? target.label : "Block", drop: null, pointer: { x: event.clientX, y: event.clientY } };
     captureOriginal(moving.el);
     moving.el.style.opacity = "0.4";
     place(els.outline, null);
     showChip(null);
+    requestAnimationFrame(autoScroll);
     try {
       els.mover.setPointerCapture(event.pointerId);
     } catch {
@@ -1427,11 +1505,35 @@ function boot() {
     }
   });
 
+  /**
+   * Near the top or bottom edge the page scrolls on its own, so a block can
+   * travel further than one screen. Runs per frame while the handle is held.
+   */
+  const EDGE = 56;
+  const autoScroll = () => {
+    if (!moving) return;
+    const { x, y } = moving.pointer;
+    let step = 0;
+    if (y < EDGE) step = -Math.ceil((EDGE - y) / 4);
+    else if (y > window.innerHeight - EDGE) step = Math.ceil((y - (window.innerHeight - EDGE)) / 4);
+    if (step) {
+      window.scrollBy(0, step);
+      const next = dropPointFor(x, y);
+      if (next) moving.drop = next;
+      showDropline(moving.drop, moving.pointer, moving.label);
+    }
+    requestAnimationFrame(autoScroll);
+  };
+
   window.addEventListener("pointermove", (event) => {
     if (!moving) return;
     event.preventDefault();
-    moving.drop = dropPointFor(event.clientX, event.clientY);
-    showDropline(moving.drop);
+    moving.pointer = { x: event.clientX, y: event.clientY };
+    // Over a margin or gutter there is no block under the pointer; keep the
+    // last real target rather than blinking the indicator off and on.
+    const next = dropPointFor(event.clientX, event.clientY);
+    if (next) moving.drop = next;
+    showDropline(moving.drop, moving.pointer, moving.label);
   });
 
   window.addEventListener("pointerup", () => {
@@ -1447,7 +1549,7 @@ function boot() {
     const next = drop.before ? drop.ref : drop.ref.nextElementSibling;
     if (next === el || (drop.before ? drop.ref.previousElementSibling : drop.ref) === el) return;
     userEdited = true;
-    undoable = { kind: "moved", el, parent: el.parentNode, next: el.nextSibling, label };
+    remember({ kind: "moved", el, parent: el.parentNode, prev: el.previousSibling, next: el.nextSibling, label });
     drop.ref.parentNode.insertBefore(el, next);
     const prev = el.previousElementSibling;
     const following = el.nextElementSibling;
@@ -1521,6 +1623,7 @@ function boot() {
 
   document.addEventListener("input", (event) => {
     if (isOurs(event.target)) return;
+    lastInputAt = Date.now();
     // A drop fires deleteByDrag/insertFromDrop input events whose selection
     // points anywhere; finalizeImageDrag writes the real rows instead.
     if (dragging) return;

--- a/test/sdk.test.js
+++ b/test/sdk.test.js
@@ -71,6 +71,39 @@ test("deleting a block reports it, offers undo, and undo restores it", { skip },
   fromChrome({ type: "eh:undo", label: "Plan · p 2", kind: "deleted" });
   const texts = [...document.querySelectorAll("p")].map((p) => p.textContent);
   assert.deepEqual(texts, ["Keep me.", "Delete me.", "Closing."], "the block is back where it was");
+  assert.ok(posts.some((m) => m.type === "eh:undone" && m.label === "Plan · p 2"), "the chrome is told so it can drop the row");
+
+  // Nothing left to restore under that label: the chrome hears that too.
+  fromChrome({ type: "eh:undo", label: "Plan · p 2", kind: "deleted" });
+  assert.ok(posts.some((m) => m.type === "eh:undoFailed"));
+});
+
+test("older deletes stay restorable, and ⌘Z undoes the latest one unless typing came after", { skip }, async () => {
+  const { window, document, posts, fromChrome, shadow } = await bootSdk("<h1>Plan</h1><p>One.</p><p>Two.</p><p>Three.</p>");
+  const [one, two, three] = document.querySelectorAll("p");
+  for (const p of [one, two]) {
+    p.dispatchEvent(new window.MouseEvent("mouseover", { bubbles: true }));
+    shadow.getElementById("chipDelete").click();
+  }
+  assert.deepEqual([...document.querySelectorAll("p")].map((p) => p.textContent), ["Three."]);
+
+  // The first deletion, not the most recent, restores from the edit list.
+  fromChrome({ type: "eh:undo", label: "Plan · p 1", kind: "deleted" });
+  assert.deepEqual([...document.querySelectorAll("p")].map((p) => p.textContent), ["One.", "Three."]);
+
+  // ⌘Z right after the remaining deletion brings the second one back.
+  document.body.dispatchEvent(new window.KeyboardEvent("keydown", { key: "z", metaKey: true, bubbles: true, cancelable: true }));
+  assert.deepEqual([...document.querySelectorAll("p")].map((p) => p.textContent), ["One.", "Two.", "Three."]);
+
+  // After typing, ⌘Z is the browser's own undo again: nothing of ours moves.
+  three.dispatchEvent(new window.MouseEvent("mouseover", { bubbles: true }));
+  shadow.getElementById("chipDelete").click();
+  one.dispatchEvent(new window.Event("input", { bubbles: true }));
+  const zed = new window.KeyboardEvent("keydown", { key: "z", metaKey: true, bubbles: true, cancelable: true });
+  document.body.dispatchEvent(zed);
+  assert.equal(zed.defaultPrevented, false);
+  assert.deepEqual([...document.querySelectorAll("p")].map((p) => p.textContent), ["One.", "Two."]);
+  assert.equal(posts.filter((m) => m.type === "eh:undone").length, 2);
 });
 
 test("typing over a selection that spans blocks reports every block it touched", { skip }, async () => {


### PR DESCRIPTION
## Summary
- **Drop indicator you can see.** A thick accent line with end caps on the edge the block drops against, a dashed outline on the target block, and a label by the pointer saying "Move 'X' above 'Y'". Over a gutter the last real target holds instead of blinking off.
- **Auto-scroll** near the top or bottom edge while dragging, so a block can travel further than one screen.
- **Undo for every delete and move**, not only the latest: the edit list gets an Undo button on those rows, and ⌘Z right after a delete or move puts the block back unless typing came after, which stays the browser's own undo. Restores anchor on whichever old neighbor is still in place. The row is dropped only after the editor confirms, and a restore that isn't possible after a reload says so.
- Fix: a block move as the first action on a page no longer flags it as self-rendering and switches saves off.
- Bumps to 0.7.2.

## Test plan
- [x] jsdom: delete + undo with confirmation, an older delete restored from the list, ⌘Z undoing the latest delete and deferring to the browser after typing
- [x] Chrome: drag indicator, outline, and label render mid-drag; drop then ⌘Z round-trips with the expected messages
- [x] `npm test` — 125 passing