### PR TITLE
0.8.0: container drops, Back button, Mermaid diagrams, editor tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "human-review",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "human-review",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "marked": "^18.0.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "human-review",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Review and edit agent-generated files and localhost pages in the browser, then send the whole batch back to your agent.",
   "author": "Peter Yang",
   "homepage": "https://github.com/petergyang/human-review#readme",

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -97,7 +97,7 @@ async function rebootstrap() {
     const fresh = await api("/api/session", { method: "POST", body: JSON.stringify({ target }) });
     state.sessionId = fresh.sessionId;
     state.artifactToken = fresh.artifactToken || state.artifactToken;
-    history.replaceState(null, "", fresh.path);
+    history.replaceState({ key: state.key }, "", `${fresh.path}?key=${encodeURIComponent(state.key)}`);
     return true;
   } catch {
     return false;
@@ -148,6 +148,33 @@ async function loadPage(key, { reload = true } = {}) {
     toast(`This page renders from your dev server — ${edits} ${edits === 1 ? "edit is" : "edits are"} queued for the agent`);
   }
 }
+
+// ------------------------------------------------------------------ history
+
+/**
+ * Each page shown in this window is a history entry, so Back returns to the
+ * previous page of the review instead of leaving it. The server's idea of
+ * the active page follows along, so a reload lands on the same page.
+ */
+function pushHistory(key) {
+  try {
+    history.pushState({ key }, "", `/s/${state.sessionId}?key=${encodeURIComponent(key)}`);
+  } catch {}
+}
+
+window.addEventListener("popstate", async (event) => {
+  const key = event.state && event.state.key;
+  if (!key || key === state.key || document.querySelector(".ended")) return;
+  await flushFrame();
+  try {
+    await api(`/api/session/${state.sessionId}/goto`, { method: "POST", body: JSON.stringify({ key }) });
+  } catch (err) {
+    toast(err.message);
+    return;
+  }
+  state.scroll = { x: 0, y: 0 };
+  await loadPage(key);
+});
 
 // -------------------------------------------------------------------- clock
 
@@ -348,6 +375,7 @@ function render() {
           body: JSON.stringify({ key: other.key }),
         });
         state.scroll = { x: 0, y: 0 };
+        pushHistory(other.key);
         await loadPage(other.key);
       });
       list.append(row);
@@ -763,6 +791,7 @@ window.addEventListener("message", async (event) => {
           body: JSON.stringify({ href: msg.href }),
         });
         state.scroll = { x: 0, y: 0 };
+        pushHistory(result.key);
         await loadPage(result.key);
       } catch (err) {
         toast(err.message);
@@ -1037,6 +1066,9 @@ function connect() {
   state.artifactToken = bootstrap.artifactToken || "";
   const leftover = bootstrap.leftover || { comments: 0, edits: 0 };
   state.leftover = leftover.comments + leftover.edits ? leftover : null;
+  try {
+    history.replaceState({ key: bootstrap.key }, "", `/s/${state.sessionId}?key=${encodeURIComponent(bootstrap.key)}`);
+  } catch {}
   await loadPage(bootstrap.key);
   connect();
 })();

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -80,6 +80,21 @@ const ARTIFACT_ORIGIN = `${location.protocol}//${ARTIFACT_HOST}:${location.port}
 const toFrame = (message) =>
   frame.contentWindow && frame.contentWindow.postMessage(message, state.framePolicy?.targetOrigin || ARTIFACT_ORIGIN);
 
+/**
+ * Point the frame at a page without adding a history entry of its own.
+ * Setting `src` records each artifact load in the window's history, so Back
+ * would step through frame loads instead of review pages.
+ */
+function showInFrame(url) {
+  try {
+    if (frame.contentWindow) {
+      frame.contentWindow.location.replace(url);
+      return;
+    }
+  } catch {}
+  frame.src = url;
+}
+
 function artifactUrl(key, bust = false) {
   const query = bust ? `?t=${Date.now()}` : "";
   return `${ARTIFACT_ORIGIN}/artifact/${state.artifactToken}/${key}/index.html${query}`;
@@ -138,7 +153,7 @@ async function loadPage(key, { reload = true } = {}) {
   clearTimeout(retryTimer);
   if (reload) {
     state.reloading = true;
-    frame.src = artifactUrl(key);
+    showInFrame(artifactUrl(key));
   }
   render();
   // Coming back to a dev-server page shows the app's own copy again, without
@@ -1015,7 +1030,7 @@ function connect() {
     // The file on disk changed: queued saves are based on the old version.
     state.baseHash = null;
     clearTimeout(retryTimer);
-    frame.src = artifactUrl(state.key, true);
+    showInFrame(artifactUrl(state.key, true));
     api(pageUrl(state.key, state.sessionId)).then((page) => {
       replacePage(state, page);
       state.save = "idle";

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -34,7 +34,25 @@ const STYLE = `
   th { background: #f7f5f0; }
   img { max-width: 100%; height: auto; }
   hr { border: none; border-top: 1px solid #eceae3; margin: 2.2em 0; }
+  .diagram { margin: 1em 0; }
+  .diagram pre.mermaid { background: none; padding: 0; text-align: center; }
+  .diagram pre.mermaid svg { max-width: 100%; height: auto; }
 `;
+
+/**
+ * Mermaid renders in the browser from a pinned CDN build, loaded only when a
+ * page has a diagram. It is not bundled: the library and its dependencies
+ * are 80 MB installed, which every `npx` user would pay for on first run.
+ * Offline, or if the load fails, the fence stays a readable code block.
+ */
+export const MERMAID_VERSION = "11.17.2";
+const MERMAID_SRC = `https://cdn.jsdelivr.net/npm/mermaid@${MERMAID_VERSION}/dist/mermaid.esm.min.mjs`;
+const MERMAID_LOADER = `<script type="module" data-eh-diagram>
+import(${JSON.stringify(MERMAID_SRC)}).then(({ default: mermaid }) => {
+  mermaid.initialize({ startOnLoad: false, securityLevel: "strict", theme: "neutral" });
+  return mermaid.run({ nodes: document.querySelectorAll("pre.mermaid") });
+}).catch(() => {});
+</script>`;
 
 const escapeHtml = (value) =>
   String(value)
@@ -68,10 +86,17 @@ INERT_RENDERER.image = function (token) {
   if (!href) return escapeHtml(token.text || "");
   return Renderer.prototype.image.call(this, { ...token, href });
 };
+// A ```mermaid fence becomes a diagram. The source stays in the element as
+// text, which is what Mermaid reads and what the review falls back to.
+INERT_RENDERER.code = function (token) {
+  if (String(token.lang || "").trim().toLowerCase() !== "mermaid") return Renderer.prototype.code.call(this, token);
+  return `<div class="diagram" data-block="Diagram"><pre class="mermaid">${escapeHtml(token.text)}</pre></div>\n`;
+};
 
 /** Render a Markdown file into a standalone review page. */
 export function renderMarkdownPage(mdText, file) {
   const body = marked.parse(mdText, { gfm: true, async: false, renderer: INERT_RENDERER });
+  const loader = body.includes('<pre class="mermaid">') ? MERMAID_LOADER : "";
   const title = path.basename(file);
   return `<!DOCTYPE html>
 <html lang="en">
@@ -81,7 +106,7 @@ export function renderMarkdownPage(mdText, file) {
 <title>${title.replace(/&/g, "&amp;").replace(/</g, "&lt;")}</title>
 <style>${STYLE}</style>
 </head>
-<body><main>${body}</main></body>
+<body><main>${body}</main>${loader}</body>
 </html>
 `;
 }

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -1477,13 +1477,28 @@ function boot() {
   // identity (labels, captured originals, comment anchors) survives the move.
   let moving = null; // { el, label, drop: { ref, before } | null } while the handle is held
 
+  /** Within this many pixels of a container's outer edge, the drop targets the container. */
+  const CONTAINER_EDGE = 10;
+
   const dropPointFor = (x, y) => {
     const under = document.elementFromPoint(x, y);
     if (!under || isOurs(under)) return null;
     const block = innermostBlock(under);
     if (!block || block === moving.el || moving.el.contains(block)) return null;
-    const r = block.getBoundingClientRect();
-    return { ref: block, before: y < r.top + r.height / 2 };
+    // Near the top or bottom edge of a card or section, the whole container
+    // is the target, so a block can be dropped past it rather than only
+    // beside one of its children. The outermost qualifying ancestor wins.
+    let chosen = block;
+    let ancestor = block.parentElement;
+    while (ancestor && ancestor !== document.body && !isOurs(ancestor)) {
+      if (ancestor !== moving.el && !moving.el.contains(ancestor) && isBlock(ancestor)) {
+        const box = ancestor.getBoundingClientRect();
+        if (y - box.top <= CONTAINER_EDGE || box.bottom - y <= CONTAINER_EDGE) chosen = ancestor;
+      }
+      ancestor = ancestor.parentElement;
+    }
+    const r = chosen.getBoundingClientRect();
+    return { ref: chosen, before: y < r.top + r.height / 2 };
   };
 
   els.mover.addEventListener("pointerdown", (event) => {

--- a/test/markdown.test.js
+++ b/test/markdown.test.js
@@ -157,3 +157,20 @@ test("a markdown review is rendered, flagged, and never writable", async (t) => 
 });
 
 test.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+test("a mermaid fence renders as a diagram with a lazy loader; other fences stay code", () => {
+  const withDiagram = renderMarkdownPage("# Flow\n\n```mermaid\ngraph TD; A-->B;\n```\n\n```js\nconst x = 1;\n```\n", "/x/flow.md");
+  assert.match(withDiagram, /<div class="diagram" data-block="Diagram"><pre class="mermaid">graph TD; A--&gt;B;<\/pre><\/div>/);
+  assert.match(withDiagram, /<pre><code class="language-js">const x = 1;/);
+  assert.match(withDiagram, /<script type="module" data-eh-diagram>/);
+  assert.match(withDiagram, /cdn\.jsdelivr\.net\/npm\/mermaid@11\.17\.2\/dist\/mermaid\.esm\.min\.mjs/);
+  assert.match(withDiagram, /securityLevel: "strict"/);
+
+  const plain = renderMarkdownPage("# Notes\n\n```js\nconst x = 1;\n```\n", "/x/notes.md");
+  assert.doesNotMatch(plain, /data-eh-diagram/, "no loader when there is nothing to render");
+
+  // Diagram source is text, never markup: a hostile fence cannot inject.
+  const hostile = renderMarkdownPage("```mermaid\n<script>alert(1)</script>\n```\n", "/x/h.md");
+  assert.doesNotMatch(hostile, /<script>alert/);
+  assert.match(hostile, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+});

--- a/test/sdk.test.js
+++ b/test/sdk.test.js
@@ -12,6 +12,8 @@ const skip = JSDOM ? false : "jsdom unavailable on this Node version";
 
 const CHROME_ORIGIN = "http://localhost:4000";
 let seq = 0;
+/** The most recent boot, so its pending timers can be flushed before the next one takes the globals. */
+let current = null;
 
 /**
  * Boot the editor SDK against a jsdom document standing in for the review
@@ -21,6 +23,13 @@ let seq = 0;
  * query so module-level state starts fresh.
  */
 async function bootSdk(body) {
+  // Every instance posts through the global `parent`. An edit still sitting in
+  // a previous instance's flush timer would land in this test's capture, so
+  // drain it while the old window is still the global one.
+  if (current) {
+    current.fromChrome({ type: "eh:flush" });
+    current = null;
+  }
   const dom = new JSDOM(`<!DOCTYPE html><html><head></head><body>${body}</body></html>`, {
     url: "http://127.0.0.1:4000/artifact/t/k/index.html",
     pretendToBeVisual: true,
@@ -58,6 +67,7 @@ async function bootSdk(body) {
   await import(`../src/sdk.js?boot=${seq}`);
   const fromChrome = (data) => window.dispatchEvent(new window.MessageEvent("message", { data, origin: CHROME_ORIGIN, source: window }));
   const shadow = window.document.querySelector("[data-eh-ui]").shadowRoot;
+  current = { fromChrome };
   return { window, document: window.document, posts, fromChrome, shadow };
 }
 

--- a/test/sdk.test.js
+++ b/test/sdk.test.js
@@ -28,6 +28,12 @@ async function bootSdk(body) {
   const { window } = dom;
   const posts = [];
   window.postMessage = (message) => posts.push(JSON.parse(JSON.stringify(message)));
+  // jsdom has no layout: give Range the geometry the link popup asks for.
+  if (!window.Range.prototype.getBoundingClientRect) {
+    const zero = () => ({ left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0 });
+    window.Range.prototype.getBoundingClientRect = zero;
+    window.Range.prototype.getClientRects = () => [];
+  }
   if (!window.CSS) window.CSS = {};
   if (!window.CSS.escape) window.CSS.escape = (value) => String(value).replace(/[^\w-]/g, (c) => `\\${c}`);
   for (const name of Object.getOwnPropertyNames(window)) {
@@ -160,4 +166,125 @@ test("labels number siblings by their order at load, so a deletion does not renu
     ["Goals · p 2", "Goals · p 3"],
     "the third paragraph keeps its number after the second is gone"
   );
+});
+
+/**
+ * jsdom has no execCommand. This stand-in does what Chrome does for the two
+ * commands the list paths use: delete the selection, and turn the block the
+ * caret is in into a list item. It fires the input event Chrome fires too.
+ */
+function installExecCommand(window) {
+  window.document.execCommand = (command) => {
+    const document = window.document;
+    const sel = window.getSelection();
+    if (command === "delete") {
+      if (sel.rangeCount) sel.getRangeAt(0).deleteContents();
+      document.body.dispatchEvent(new window.Event("input", { bubbles: true }));
+      return true;
+    }
+    if (command === "insertUnorderedList" || command === "insertOrderedList") {
+      let node = sel.anchorNode;
+      let block = node && (node.nodeType === 1 ? node : node.parentElement);
+      while (block && block !== document.body && !/^(p|div|h[1-6])$/i.test(block.tagName)) block = block.parentElement;
+      if (!block || block === document.body) return false;
+      const list = document.createElement(command === "insertOrderedList" ? "ol" : "ul");
+      const item = document.createElement("li");
+      while (block.firstChild) item.appendChild(block.firstChild);
+      list.appendChild(item);
+      block.replaceWith(list);
+      const range = document.createRange();
+      range.selectNodeContents(item);
+      range.collapse(false);
+      sel.removeAllRanges();
+      sel.addRange(range);
+      item.dispatchEvent(new window.Event("input", { bubbles: true }));
+      return true;
+    }
+    return false;
+  };
+}
+
+test("typing a list marker turns the paragraph into a list under the paragraph's own label", { skip }, async () => {
+  const { window, document, posts, fromChrome } = await bootSdk("<h2>Goals</h2><p>-Ship it.</p>");
+  installExecCommand(window);
+  const p = document.querySelector("p");
+  const range = document.createRange();
+  range.setStart(p.firstChild, 1);
+  range.collapse(true);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+  const space = new window.KeyboardEvent("keydown", { key: " ", bubbles: true, cancelable: true });
+  p.dispatchEvent(space);
+  assert.equal(space.defaultPrevented, true, "the marker keystroke is consumed");
+  assert.equal(document.querySelector("ul li").textContent, "Ship it.");
+  fromChrome({ type: "eh:flush" });
+  assert.deepEqual(rows(posts), [{ label: "Goals · p", kind: "edited", before: "-Ship it.", after: "Ship it." }]);
+  const row = posts.find((m) => m.type === "eh:edit");
+  assert.match(row.after_html, /^<li>Ship it\.<\/li>$/);
+});
+
+test("⌘K on an existing link retargets it, and Remove unwraps it, each as one edit row", { skip }, async () => {
+  const { window, document, posts, fromChrome, shadow } = await bootSdk('<h2>Links</h2><p>Read <a href="https://old.example">the spec</a> first.</p>');
+  const anchor = document.querySelector("a");
+  const caret = document.createRange();
+  caret.setStart(anchor.firstChild, 2);
+  caret.collapse(true);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(caret);
+
+  const k = new window.KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true, cancelable: true });
+  anchor.dispatchEvent(k);
+  assert.equal(k.defaultPrevented, true);
+  const input = shadow.getElementById("linkInput");
+  assert.equal(input.value, "https://old.example", "the popup opens on the link's current target");
+  input.value = "new.example/spec";
+  input.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+  assert.equal(anchor.getAttribute("href"), "https://new.example/spec", "a bare domain gets a scheme");
+  fromChrome({ type: "eh:flush" });
+  assert.deepEqual(rows(posts), [{ label: "Links · p", kind: "edited", before: "Read the spec first.", after: "Read the spec first." }]);
+  assert.match(posts.find((m) => m.type === "eh:edit").after_html, /href="https:\/\/new\.example\/spec"/);
+
+  posts.length = 0;
+  sel.removeAllRanges();
+  sel.addRange(caret);
+  anchor.dispatchEvent(new window.KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true, cancelable: true }));
+  shadow.getElementById("linkRemove").click();
+  assert.equal(document.querySelector("a"), null, "the link is gone, its text stays");
+  assert.equal(document.querySelector("p").textContent, "Read the spec first.");
+  fromChrome({ type: "eh:flush" });
+  const removed = posts.find((m) => m.type === "eh:edit");
+  assert.equal(removed.after_html, "<p>Read the spec first.</p>");
+});
+
+test("a pasted image lands at the caret once the chrome confirms where it was saved", { skip }, async () => {
+  const { window, document, posts, fromChrome } = await bootSdk("<h2>Design</h2><p>Before the image.</p>");
+  const p = document.querySelector("p");
+  const caret = document.createRange();
+  caret.setStart(p.firstChild, p.firstChild.length);
+  caret.collapse(true);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(caret);
+
+  const paste = new window.Event("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(paste, "clipboardData", {
+    value: { items: [{ kind: "file", type: "image/png", getAsFile: () => ({ type: "image/png", arrayBuffer: async () => new ArrayBuffer(4) }) }] },
+  });
+  p.dispatchEvent(paste);
+  assert.equal(paste.defaultPrevented, true, "the SDK owns image pastes");
+  for (let i = 0; i < 50 && !posts.some((m) => m.type === "eh:asset"); i += 1) await new Promise((resolve) => setTimeout(resolve, 10));
+  const asset = posts.find((m) => m.type === "eh:asset");
+  assert.ok(asset, "the bytes go to the chrome to be saved");
+  assert.equal(asset.assetType, "image/png");
+
+  fromChrome({ type: "eh:assetSaved", id: asset.id, src: "assets/design-paste-1.png" });
+  const img = document.querySelector("p img");
+  assert.ok(img, "the image is inserted at the caret");
+  assert.equal(img.getAttribute("src"), "assets/design-paste-1.png");
+  const row = posts.find((m) => m.type === "eh:edit");
+  assert.equal(row.label, "Design · p");
+  assert.equal(row.before, "Before the image.");
+  assert.match(row.after_html, /<img src="assets\/design-paste-1\.png"/);
 });


### PR DESCRIPTION
## Summary
- **Drop past a whole card.** Near the top or bottom edge of a container, the drop targets the container itself, so a block can be moved past a card or section as a unit instead of only beside one of its children. The drag label names the container.
- **Back button works in multi-page reviews** (issue #27). Each page shown in a window is a history entry; Back and Forward step between pages, the server's active page follows, and a reload lands on the same page. The frame is navigated with `location.replace` so frame loads don't pollute history.
- **Mermaid diagrams in Markdown reviews** (issues #34, #35, the diagram half of #39). A `mermaid` fence renders as a diagram, loaded lazily from a pinned CDN build only on pages that have one, `securityLevel: strict`. Offline, or if the load fails, the fence stays a readable code block. The library is deliberately not bundled: it and its dependencies are 80 MB installed, which every `npx` user would pay on first run. Diagram source is escaped text, never markup.
- **Editor tests** under jsdom for the list marker, ⌘K link edit and remove, and image paste paths, alongside the existing delete, undo, multi-block, and keyboard-selection tests.

## Test plan
- [x] `npm test` — 129 passing
- [x] Chrome: a Markdown page with a mermaid fence renders the diagram inside the review; navigate to a second page, Back returns to the first, Forward returns to the second, one history entry per page, no console errors