### PR TITLE
Count only unsent feedback after a Send

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "human-review",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "human-review",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "marked": "^18.0.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "human-review",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Review and edit agent-generated files and localhost pages in the browser, then send the whole batch back to your agent.",
   "author": "Peter Yang",
   "homepage": "https://github.com/petergyang/human-review#readme",

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -251,7 +251,12 @@ function render() {
     when.textContent = ago(comment.updatedAt || comment.createdAt);
     who.append(sep, when);
 
-    if (comment.updatedAt) {
+    if (comment.sent) {
+      const badge = document.createElement("span");
+      badge.className = "badge sent";
+      badge.textContent = "sent";
+      who.append(badge);
+    } else if (comment.updatedAt) {
       const badge = document.createElement("span");
       badge.className = "badge";
       badge.textContent = "edited";
@@ -326,7 +331,7 @@ function render() {
     const shown = state.editsExpanded ? edits : edits.slice(0, LIMIT);
     for (const edit of shown) {
       const row = document.createElement("div");
-      row.className = `edit-row${edit.kind === "deleted" ? " deleted" : ""}`;
+      row.className = `edit-row${edit.kind === "deleted" ? " deleted" : ""}${edit.sent ? " sent" : ""}`;
       const pip = document.createElement("span");
       pip.className = "pip";
       const label = document.createElement("span");
@@ -334,9 +339,9 @@ function render() {
       label.textContent = edit.label;
       const kind = document.createElement("span");
       kind.className = "kind";
-      kind.textContent = edit.kind;
+      kind.textContent = edit.sent ? `${edit.kind} · sent` : edit.kind;
       row.append(pip, label, kind);
-      if (edit.kind === "deleted" || edit.kind === "moved") {
+      if (!edit.sent && (edit.kind === "deleted" || edit.kind === "moved")) {
         const undo = document.createElement("button");
         undo.type = "button";
         undo.className = "row-undo";
@@ -397,9 +402,11 @@ function render() {
     }
   }
 
-  // --- send
+  // --- send: only what the agent does not have yet counts. Items from a
+  // batch that is delivered or queued stay listed until the ack, marked sent.
   const otherTotal = others.reduce((sum, o) => sum + o.count, 0);
-  const total = comments.length + edits.length + otherTotal;
+  const unsent = page.unsent || { comments: comments.length, edits: edits.length };
+  const total = unsent.comments + unsent.edits + otherTotal;
   // An overall note is sendable on its own — the server already accepts
   // note-only batches; the button must not stay dead while one is typed.
   const hasNote = $("note").value.trim().length > 0;
@@ -409,11 +416,12 @@ function render() {
   const stranded = state.agent === "stranded";
   // While the agent works, anything new can still be sent: it queues behind
   // the batch in flight and ships with the agent's next poll.
-  const busy = stranded || state.sent || (queued && total === 0 && !hasNote);
-  send.disabled = (total === 0 && !hasNote) || busy;
+  const nothingNew = total === 0 && !hasNote;
+  const busy = stranded || state.sent || (queued && nothingNew);
+  send.disabled = nothingNew || busy;
   send.textContent = stranded
     ? "Sent — agent is not listening"
-    : state.sent
+    : state.sent || (nothingNew && (delivered || queued))
       ? queued
         ? "Sent — queued for the agent"
         : delivered

--- a/src/chrome.css
+++ b/src/chrome.css
@@ -498,3 +498,8 @@ body.collapsed .handle { right: 0; }
   cursor: pointer;
 }
 .edit-row .row-undo:hover { background: var(--soft); color: var(--strong-txt); border-color: var(--strong-border); }
+
+/* Feedback the agent already has stays listed until it acks, but reads as done. */
+.badge.sent { background: var(--soft); color: var(--green); }
+.edit-row.sent { opacity: .55; }
+.edit-row.sent .pip { background: var(--green); }

--- a/src/server.js
+++ b/src/server.js
@@ -228,6 +228,27 @@ export function createServer() {
     for (const session of sessionsForEntry(entryKey)) emit(session, "agent", { state });
   }
 
+  /**
+   * What a page's feedback the agent already has, or that is waiting for it:
+   * every comment id and edit timestamp covered by a batch that is sent and
+   * not yet acked. Those items stay on the page until the ack, but they are
+   * not sendable again, and the browser must not count them as if they were.
+   */
+  function coverageFor(key) {
+    const ids = new Set();
+    let sentAt = 0;
+    for (const record of batches.values()) {
+      for (const entry of [...(record.priorCleanup || []), ...record.cleanup]) {
+        if (entry.key !== key) continue;
+        for (const id of entry.ids) ids.add(id);
+        sentAt = Math.max(sentAt, entry.sentAt || 0);
+      }
+    }
+    return { ids, sentAt };
+  }
+
+  const isSentEdit = (edit, coverage) => (edit.updatedAt || edit.at || 0) < coverage.sentAt;
+
   /** Unsent feedback on every page reachable from this entry target. */
   function unsentCounts(entryKey) {
     const keys = new Set([entryKey]);
@@ -240,8 +261,9 @@ export function createServer() {
     for (const k of keys) {
       const page = store.page(k);
       if (!page) continue;
-      comments += page.comments.length;
-      edits += page.edits.length;
+      const coverage = coverageFor(k);
+      comments += page.comments.filter((c) => !coverage.ids.has(c.id)).length;
+      edits += page.edits.filter((e) => !isSentEdit(e, coverage)).length;
     }
     return { comments, edits };
   }
@@ -393,15 +415,23 @@ export function createServer() {
     return out;
   }
 
-  /** Pages with feedback that are not the one on screen. */
+  /** Pages with feedback still to send that are not the one on screen. */
   function otherPages(session) {
-    return collectPages(session)
-      .filter((p) => p.key !== session.activeKey)
-      .map((p) => ({
-        key: p.key,
-        filename: p.kind === "url" ? new URL(p.url).pathname || p.url : path.basename(p.file),
-        count: p.comments.length + p.edits.length,
-      }));
+    const out = [];
+    for (const key of session.visited) {
+      if (key === session.activeKey) continue;
+      const page = store.page(key);
+      if (!page) continue;
+      const coverage = coverageFor(key);
+      const count = page.comments.filter((c) => !coverage.ids.has(c.id)).length + page.edits.filter((e) => !isSentEdit(e, coverage)).length;
+      if (!count) continue;
+      out.push({
+        key,
+        filename: page.kind === "url" ? new URL(page.url).pathname || page.url : path.basename(page.file),
+        count,
+      });
+    }
+    return out;
   }
 
   function sendBatch(sessionId, note) {
@@ -637,6 +667,7 @@ export function createServer() {
     const entry = session ? store.page(session.entryKey) : null;
     const currentTarget = page.kind === "url" ? page.url : page.file;
     const pollTarget = entry ? (entry.kind === "url" ? entry.url : entry.file) : currentTarget;
+    const coverage = coverageFor(key);
     return {
       key: page.key,
       kind: page.kind === "url" ? "url" : "file",
@@ -645,8 +676,12 @@ export function createServer() {
       filename: page.kind === "url" ? new URL(page.url).pathname || page.url : path.basename(page.file),
       markdown: page.kind !== "url" && isMarkdown(page.file),
       feedbackOnly: page.kind === "url",
-      comments: page.comments,
-      edits: page.edits,
+      comments: page.comments.map((c) => ({ ...c, sent: coverage.ids.has(c.id) })),
+      edits: page.edits.map((e) => ({ ...e, sent: isSentEdit(e, coverage) })),
+      unsent: {
+        comments: page.comments.filter((c) => !coverage.ids.has(c.id)).length,
+        edits: page.edits.filter((e) => !isSentEdit(e, coverage)).length,
+      },
       canRevert: page.kind !== "url" && typeof page.pristine === "string" && page.pristine.length > 0,
       pollCommand: `${cliInvocation} poll ${shellQuote(pollTarget)}`,
     };

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -411,3 +411,47 @@ test("the artifact route needs the per-run secret, and a localhost app's own req
 });
 
 test.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+test("feedback the agent already has is marked sent and no longer counted, on this page or others", async (t) => {
+  const first = htmlFile("multi-a.html", '<p>Alpha</p><a href="multi-b.html">next</a>');
+  htmlFile("multi-b.html", "<p>Beta</p>");
+  const { port, token, dispose } = await start(0);
+  t.after(() => dispose());
+  const opened = await open(port, token, first);
+  await comment(port, token, opened.key, "Alpha", "First thought");
+  await edit(port, token, opened.key, { label: "p", before: "Alpha", after: "Alpha!" });
+
+  const waiting = poll(port, token, first);
+  await sleep(30);
+  await send(port, token, opened.key, opened.sessionId);
+  await waiting.promise;
+
+  // On the same page: everything is still listed, all of it marked sent.
+  let page = j(await request(port, token, { route: `/api/page/${opened.key}?session=${opened.sessionId}` }));
+  assert.deepEqual(page.comments.map((c) => c.sent), [true]);
+  assert.deepEqual(page.edits.map((e) => e.sent), [true]);
+  assert.deepEqual(page.unsent, { comments: 0, edits: 0 });
+
+  // Navigate to a second page: the first must not show up as sendable.
+  const moved = j(await request(port, token, { method: "POST", route: `/api/session/${opened.sessionId}/navigate`, body: { href: "multi-b.html" } }));
+  const boot = j(await request(port, token, { route: `/api/session/${opened.sessionId}/page` }));
+  assert.equal(boot.key, moved.key);
+  assert.deepEqual(boot.others, [], "the delivered batch's items are not counted as other-page feedback");
+
+  // New feedback after the send is unsent, and counted.
+  await sleep(15);
+  await comment(port, token, opened.key, "Alpha", "Second thought");
+  const again = j(await request(port, token, { route: `/api/session/${opened.sessionId}/page` }));
+  assert.deepEqual(again.others.map((o) => o.count), [1]);
+  page = j(await request(port, token, { route: `/api/page/${opened.key}` }));
+  assert.deepEqual(page.comments.map((c) => c.sent), [true, false]);
+  assert.deepEqual(page.unsent, { comments: 1, edits: 0 });
+
+  // After the ack the delivered items are gone and only the new one remains.
+  const acked = poll(port, token, first, { ack: true });
+  await sleep(50);
+  page = j(await request(port, token, { route: `/api/page/${opened.key}` }));
+  assert.deepEqual(page.comments.map((c) => [c.feedback, c.sent]), [["Second thought", false]]);
+  assert.deepEqual(page.edits, []);
+  acked.req.destroy();
+});


### PR DESCRIPTION
## Summary
After Send, the sent items stay on the page until the agent acks, and the Send button counted them again as soon as the user navigated to another page: "Send 14 to agent" while the agent was working on those 14. Clicking would have failed with "nothing new", but the count was wrong.

- The server marks every comment and edit covered by a sent, unacked batch as `sent`, reports `unsent` counts per page, and lists other pages by unsent items only.
- Sent rows read as done (dimmed, "edited · sent"), lose their Undo button, and comments get a "sent" badge.
- The button says "Feedback delivered" or "queued" while nothing new exists, on any page of the review.
- Bumps to 0.8.1.

## Test plan
- [x] New test: send on page A with a poll attached, navigate to page B, page A is not counted; new feedback after the send is counted; ack clears the sent items
- [x] Chrome: two edits, Send, navigate to a second page shows "Feedback delivered" with no other-page count; Back shows both rows marked sent
- [x] `npm test` — 130 passing