### PR TITLE
Name a container by the heading it holds, not the previous section's

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -372,6 +372,33 @@ function cssPath(el) {
   return ["body", ...parts].join(" > ");
 }
 
+/** Blocks that carry their title somewhere inside them, not necessarily at the top. */
+const TITLED = /^(header|section|article|aside|nav|main)$/i;
+/** Sectioning roots own their own headings, so the walk must not cross into one. */
+const OWN_STOP = /^(section|article|aside|nav|main|figure)$/i;
+const isHeading = (el) => /^h[1-6]$/i.test(el.tagName);
+
+/**
+ * The heading element a block holds as its own title, or null when it holds
+ * none. An element, not a string: a present-but-blank title has to stay
+ * distinguishable from no title, or the caller falls back and mislabels the block.
+ */
+function ownHeadingEl(el) {
+  if (!el || el.nodeType !== 1) return null;
+  // A list, a table, a plain wrapper: a heading buried in its content belongs to
+  // that content, so only a direct child can be the block's own title.
+  if (!TITLED.test(el.tagName)) return [...el.children].find(isHeading) || null;
+  const queue = [...el.children];
+  while (queue.length) {
+    const node = queue.shift();
+    if (isHeading(node)) return node;
+    // A heading inside a nested sectioning root titles that root, not this block.
+    if (OWN_STOP.test(node.tagName)) continue;
+    queue.unshift(...node.children);
+  }
+  return null;
+}
+
 /** The heading a block sits under, used to name edits in arbitrary HTML. */
 function precedingHeading(el) {
   let node = el;
@@ -434,8 +461,14 @@ function targetFor(node) {
   }
 
   if (!pinnedLabels.has(block)) {
-    // A heading names itself; the heading before it would mislabel the edit.
-    const heading = /^h[1-6]$/i.test(block.tagName) ? "" : precedingHeading(block);
+    // A heading names itself; the heading before it would mislabel the edit. A
+    // container is named by the heading it holds, which the preceding-heading
+    // walk skips over, because that walk only ever looks at earlier siblings.
+    let heading = "";
+    if (!/^h[1-6]$/i.test(block.tagName)) {
+      const own = ownHeadingEl(block);
+      heading = own ? own.textContent.trim() : precedingHeading(block);
+    }
     const tag = block.tagName.toLowerCase();
     // Siblings of the same tag would otherwise share a label and collapse into
     // one edit row, so number them — by their order at load, not right now.

--- a/test/sdk.test.js
+++ b/test/sdk.test.js
@@ -298,3 +298,73 @@ test("a pasted image lands at the caret once the chrome confirms where it was sa
   assert.equal(row.before, "Before the image.");
   assert.match(row.after_html, /<img src="assets\/design-paste-1\.png"/);
 });
+
+// --------------------------------------------------- container title labels
+
+/** The label the SDK gives one element, read off the row a delete reports. */
+async function labelFor(body, selector) {
+  const { window, document, posts, shadow } = await bootSdk(body);
+  const el = document.querySelector(selector);
+  el.dispatchEvent(new window.MouseEvent("mouseover", { bubbles: true }));
+  shadow.getElementById("chipDelete").click();
+  const [row] = rows(posts);
+  return row ? row.label : null;
+}
+
+const SECTIONS = `
+  <section id="a"><header><h2>First section</h2></header><p>Body A.</p></section>
+  <section id="b"><header><h2>Second section</h2></header><p>Body B.</p></section>
+`;
+
+test("a header is named by the heading it holds, not the previous section's", { skip }, async () => {
+  assert.equal(await labelFor(SECTIONS, "#b > header"), "Second section · header");
+});
+
+test("a section is named by its own heading, through the header that wraps it", { skip }, async () => {
+  // Two <section> siblings, so the existing ordinal names which one this is.
+  assert.equal(await labelFor(SECTIONS, "#b"), "Second section · section 2");
+});
+
+test("a heading keeps exactly the label it has today", { skip }, async () => {
+  assert.equal(await labelFor(SECTIONS, "#b h2"), "Second section");
+});
+
+test("a wrapper spanning several sections adopts neither one's heading", { skip }, async () => {
+  const body = `<div id="page">
+    <section><h2>Accounts</h2><p>A.</p></section>
+    <section><h2>Billing</h2><p>B.</p></section>
+  </div>`;
+  const label = await labelFor(body, "#page");
+  assert.notEqual(label, "Accounts · div", "the first child section does not title the wrapper");
+  assert.notEqual(label, "Billing · div");
+});
+
+test("an outer article does not take the heading of an article nested in it", { skip }, async () => {
+  const body = `<article id="outer">
+    <p>Outer introduction.</p>
+    <article><h2>Inner article</h2><p>Inner.</p></article>
+  </article>`;
+  assert.notEqual(await labelFor(body, "#outer"), "Inner article · article");
+});
+
+test("an aside before the real header does not title the section", { skip }, async () => {
+  const body = `<section id="s">
+    <aside><h3>Related links</h3></aside>
+    <header><h2>Billing</h2></header>
+    <p>Body.</p>
+  </section>`;
+  assert.equal(await labelFor(body, "#s"), "Billing · section");
+});
+
+test("a nav heading does not outrank the site title beside it", { skip }, async () => {
+  const body = `<header id="site"><nav><h2>Menu</h2></nav><h1>Acme</h1></header>`;
+  assert.equal(await labelFor(body, "#site"), "Acme · header");
+});
+
+test("a blank heading does not send the label back to the previous section", { skip }, async () => {
+  const body = `
+    <section id="a"><h2>First section</h2><p>Body A.</p></section>
+    <section id="b"><h2>   </h2><p>Actual body text.</p></section>
+  `;
+  assert.notEqual(await labelFor(body, "#b"), "First section · section");
+});


### PR DESCRIPTION

## The bug

`targetFor()` labels a block with `precedingHeading()`, which only ever inspects
*earlier siblings* and their subtrees before climbing to the parent. It never
looks inside the block it was handed.

That is right for a paragraph. It is wrong for a heading's container. When the
block is the `<header>` around an `<h2>`, or the `<section>` around that header,
the walk steps past the container's own title, climbs out, finds the previous
sibling section, and returns the last heading in *that* subtree. The label names
the section before the one you are pointing at.

Headings themselves already avoid this — the `/^h[1-6]$/` self-test added in
0.8.0 short-circuits them to `""`. Containers are the case that self-test does
not cover.

This finishes #26, which reported the heading half of the same defect. The fix
suggested there landed in 0.8.0 and the issue is still open; the container case
it left behind is what this patch closes.

## It is reachable with an ordinary pointer

A heading with `margin: 0` does not cover its container's padding, so the
padding bands hit-test to the container. Measured in Chrome on a `<header>` with
`padding: 28px`:

| Point | `document.elementFromPoint` |
| --- | --- |
| header top padding | `header` |
| header bottom padding | `header` |
| header left padding | `header` |
| on the heading text | `h2` |

Both `mouseover` and `mouseup` route through `targetFor()`, so both mislabel.

## The fix

`ownHeadingEl()` returns the heading element a block holds as its own title, or
`null`. Two rules keep it from over-reaching:

- **Only `header` and the sectioning roots get a descendant walk**, and that walk
  stops at a nested sectioning root, whose heading titles the root rather than
  this block. Without the stop, a `<div>` wrapping two `<section>`s would take
  the first section's heading.
- **Every other block is titled only by a direct child heading.** A list, a
  table, a plain wrapper is not named by a heading buried in its content.
  Without this rule an `<ol>` of steps takes the `<h3>` of its first `<li>` —
  a regression an earlier draft of this patch produced, which the whole-page
  diff below caught.

It returns the element rather than its text on purpose. A present-but-blank
heading has to stay distinguishable from no heading; collapsing both to `""`
sends the caller back to `precedingHeading()` and reproduces the bug.

## Heading labels are deliberately unchanged

`label` is also the edit identity: the client queue keys a `Map` on label plus
kind, and the server merges rows on the same pair. Any change that shortens
heading text creates new collisions, and a merged row can end up holding one
block's `before` and another block's `after`.

Routing headings through the new helper would have clipped every heading label
from 40 characters to 26 and added a tag suffix. This patch leaves the existing
heading branch exactly as it is, so no label is shortened and no new key
collides. Only container labels move.

## Measured on a real page

Every label the SDK computes for a production marketing page, before and after.
179 elements walked, resolving to 121 distinct review targets carrying 95 labels:

- 25 labels changed. Every one is a container that now names itself instead of
  the section above it.
- Distinct targets sharing a label with another target: **17 before, 17 after**
  (43 targets before, 42 after). One collision appears, one disappears. The
  patch is neutral on identity.

Worth flagging separately: that page has 17 colliding labels *today*, without
this patch. Label-as-identity is a live data-loss path and deserves its own
issue — `cssPath(target.el)` already exists and would serve as a stable key.
This patch neither worsens nor fixes it.

## Tests

Eight cases in `test/sdk.test.js`. Four fail without the patch:

- a `<header>` is named by the heading it holds
- a `<section>` is named through the header that wraps it
- an `<aside>` before the real header does not title the section
- a `<nav>` heading does not outrank the `<h1>` beside it

Four pass with and without it, guarding against over-reach:

- a heading keeps exactly the label it has today
- a wrapper spanning several sections adopts neither one's heading
- an outer `<article>` does not take a nested article's heading
- a blank heading does not send the label back to the previous section

Full suite: 138 passing, 0 skipped.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
